### PR TITLE
Add MitsubishiRx library, protocol support, and docs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Chris Pulman</Authors>
-    <Description>A Reactive Allen Bradley PLC library</Description>
+    <Description>Reactive Mitsubishi Ethernet and serial PLC library using MC Protocol / SLMP.</Description>
     <Copyright>Copyright © https://github.com/ChrisPulman $([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <IsTestProject>$(MSBuildProjectName.Contains('Tests'))</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -14,13 +14,14 @@
     <Nullable>enable</Nullable>
     <PackageIcon>logo.png</PackageIcon>
     <Configurations>Debug;Release;PreRelease</Configurations>
-    <PackageReleaseNotes>Compatability with Net 6 and netstandard2.0</PackageReleaseNotes>
-    <PackageTags>Rockwell;AB;Allen;Bradley;PLC;Micrologix;Controllogix;CompactLogix;PLC-5;rx;reactive;extensions;observable;LINQ;net;netstandard</PackageTags>
+    <PackageReleaseNotes>ReactiveUI.Extensions- and SerialPortRx-based Mitsubishi PLC support across Ethernet (1E/3E/4E) and serial (1C/3C/4C) MC protocol frames.</PackageReleaseNotes>
+    <PackageTags>Mitsubishi;MELSEC;PLC;MCProtocol;SLMP;Ethernet;Serial;SerialPortRx;ReactiveUI;Rx;Observable;Reactive;IndustrialAutomation</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
 
-    <PackageProjectUrl>https://github.com/ChrisPulman/ABPlcRx</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/ChrisPulman/ABPlcRx</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/ChrisPulman/MitsubishiRx</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/ChrisPulman/MitsubishiRx</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!--https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/-->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -44,22 +45,9 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)images\logo.png" Pack="true" PackagePath="\"/>
     <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="LICENSE" />
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -1,100 +1,1837 @@
 # MitsubishiRx
 
-A Reactive Mitsubishi PLC Driver written in C#. This library provides an easy-to-use, reactive interface for communicating with Mitsubishi PLCs, enabling efficient and clean code for automation and control applications.
+Reactive Mitsubishi PLC client for **MC Protocol / SLMP** in C# with **ReactiveUI.Extensions** and **SerialPortRx** integration.
 
-## Features
+This README is the **primary usage guide** for the library. It explains:
+- which PLC families, Ethernet frame types, and serial frame types are supported
+- how to configure TCP/UDP/serial transports, binary/ASCII encodings, serial message formats, and X/Y notation
+- how to use every public feature exposed by the client
+- how to build and import a **tag database** so application code can use **tag names instead of PLC addresses**
+- what CSV format is required to initialize the tag database
 
-- Reactive programming for PLC communication
-- High-performance and easy-to-integrate
-- Supports Mitsubishi PLC communication protocols
-- Simplifies interaction with PLC devices
+---
 
-## Installation
-
-To install MitsubishiRx, add the library to your project using NuGet Package Manager:
+## Install
 
 ```bash
-Install-Package MitsubishiRx
+dotnet add package MitsubishiRx
 ```
-Alternatively, add it via the .csproj file:
-```
-<PackageReference Include="MitsubishiRx" Version="1.0.0" />
-```
-## Getting Started
-Here's an example of how to use MitsubishiRx to communicate with a Mitsubishi PLC:
 
-## Basic Example
-```C#
-using System;
+---
+
+## What this library provides
+
+MitsubishiRx was refactored from a low-level socket wrapper into a protocol-aware Mitsubishi PLC client that:
+
+- supports **1E**, **3E**, and **4E** Ethernet frame families
+- supports **1C**, **3C**, and **4C** serial frame families
+- supports **TCP**, **UDP**, and reactive **serial** transports
+- uses **SerialPortRx** for reactive serial communications
+- supports **binary** and **ASCII** MC Protocol / SLMP packet encodings
+- supports direct device addressing and symbolic **tag-name-based** access
+- exposes high-level async APIs for reads, writes, remote control, monitor, block, random, loopback, memory, and diagnostics operations
+- exposes **ReactiveUI.Extensions**-based polling and health streams for reactive applications
+- includes **TUnit** tests running on **Microsoft Testing Platform**
+
+---
+
+## Supported PLC families and how to choose settings
+
+The library now covers Mitsubishi **Ethernet and serial MC protocol paths**. Ethernet support remains the broadest and deepest implementation. Serial support is now integrated through **SerialPortRx** and currently provides the first verified reactive serial path.
+
+### Supported family guidance
+
+| PLC family / endpoint type | Typical frame | Transport | Notes |
+|---|---|---|---|
+| **A / AnS** with legacy Ethernet interfaces | **1E** | TCP/UDP | Use when the target only exposes legacy A-compatible MC protocol behavior. |
+| **QnA-compatible Ethernet endpoints** | **3E** | TCP/UDP | Default modern choice for most Q/QnA-compatible MC protocol use. |
+| **Q / L / iQ-R / iQ-F / FX5** with modern SLMP/MC protocol endpoints | **3E** or **4E** | TCP/UDP | 3E is the normal first choice. 4E is used when serial correlation is required. |
+| **FX3 compatibility paths** | **1E** or **3E** depending on module/path | TCP/UDP | Use the path documented for the installed Ethernet interface or gateway. |
+| **FX3 / A-compatible serial computer-link style paths** | **1C** | Serial | Use for installed bases exposing serial MC / computer link compatible message structures. |
+| **QnA-compatible serial modules** | **3C** | Serial | ASCII serial MC protocol path. |
+| **QnA-compatible serial modules with extended access** | **4C** | Serial | ASCII or binary serial MC protocol path, depending on configured format. |
+
+### Transport selection
+
+| Transport | When to use |
+|---|---|
+| `MitsubishiTransportKind.Tcp` | Default choice for most PLC integrations. Use when you want connection-oriented request/response behavior. |
+| `MitsubishiTransportKind.Udp` | Use when the target is configured for UDP SLMP/MC protocol and you want datagram-style communication. |
+| `MitsubishiTransportKind.Serial` | Use for RS-232/RS-422/RS-485 MC protocol communication. The library uses **SerialPortRx** to provide the reactive serial transport implementation. |
+
+### Data encoding selection
+
+| Encoding | When to use |
+|---|---|
+| `CommunicationDataCode.Binary` | Default for most applications. Smaller frames and simpler payload handling. Required for `4C` serial format 5. |
+| `CommunicationDataCode.Ascii` | Use when the target requires ASCII MC protocol / SLMP or when matching existing ASCII integrations. Required for `1C` and `3C`. |
+
+### Serial message format selection
+
+Serial MC protocol communication also depends on the serial **message format** configured on the PLC/module side.
+
+| Serial message format | Meaning | Typical use |
+|---|---|---|
+| `MitsubishiSerialMessageFormat.Format1` | ASCII serial framing with ENQ/STX/ACK/NAK control characters | Legacy 1C/3C/4C serial ASCII integrations |
+| `MitsubishiSerialMessageFormat.Format4` | ASCII serial framing with CR/LF delimiters | Serial endpoints configured for CR/LF terminated MC protocol |
+| `MitsubishiSerialMessageFormat.Format5` | Binary serial framing using DLE/STX/ETX | `4C` binary serial communication |
+
+### X/Y addressing notation
+
+Mitsubishi `X` and `Y` device addressing is module/family dependent. The client makes that explicit.
+
+| Setting | Meaning |
+|---|---|
+| `XyAddressNotation.Octal` | Interpret `X10` as octal `8`. This is common for classic Mitsubishi behavior. |
+| `XyAddressNotation.Hexadecimal` | Interpret `X10` as hexadecimal `16`. Use when the Ethernet path/module is documented that way. |
+
+---
+
+## Core configuration
+
+All communication starts from `MitsubishiClientOptions`.
+
+```csharp
 using MitsubishiRx;
 
-class Program
+var options = new MitsubishiClientOptions(
+    Host: "192.168.0.10",
+    Port: 5000,
+    FrameType: MitsubishiFrameType.ThreeE,
+    DataCode: CommunicationDataCode.Binary,
+    TransportKind: MitsubishiTransportKind.Tcp,
+    Route: MitsubishiRoute.Default,
+    MonitoringTimer: 0x0010,
+    Timeout: TimeSpan.FromSeconds(4),
+    CpuType: CpuType.None,
+    XyNotation: XyAddressNotation.Octal);
+```
+
+### Option reference
+
+| Option | Meaning |
+|---|---|
+| `Host` | PLC IP address / DNS name for Ethernet, or serial port name such as `COM3` when using serial transport |
+| `Port` | Ethernet port exposed by the PLC/module. Use `0` for serial transport. |
+| `FrameType` | `OneE`, `ThreeE`, `FourE`, `OneC`, `ThreeC`, or `FourC` |
+| `DataCode` | `Binary` or `Ascii` |
+| `TransportKind` | `Tcp`, `Udp`, or `Serial` |
+| `Route` | SLMP route metadata for 3E/4E |
+| `MonitoringTimer` | PLC-side monitoring timer in 250 ms units |
+| `Timeout` | Client-side transport timeout |
+| `CpuType` | Optional family hint |
+| `XyNotation` | Octal or hexadecimal parsing for `X`/`Y` |
+| `LegacyPcNumber` | 1E PC number |
+| `SerialNumberProvider` | 4E serial number generator |
+| `Serial` | `MitsubishiSerialOptions` describing the serial port and serial MC protocol framing |
+
+### Serial transport configuration
+
+When using serial MC protocol communication, populate the `Serial` option and set `TransportKind.Serial`.
+
+```csharp
+using MitsubishiRx;
+using System.IO.Ports;
+
+var serialOptions = new MitsubishiClientOptions(
+    Host: "COM3",
+    Port: 0,
+    FrameType: MitsubishiFrameType.FourC,
+    DataCode: CommunicationDataCode.Binary,
+    TransportKind: MitsubishiTransportKind.Serial,
+    Timeout: TimeSpan.FromSeconds(2),
+    CpuType: CpuType.Fx5,
+    Serial: new MitsubishiSerialOptions(
+        PortName: "COM3",
+        BaudRate: 9600,
+        DataBits: 7,
+        Parity: Parity.Even,
+        StopBits: StopBits.One,
+        Handshake: Handshake.None,
+        MessageFormat: MitsubishiSerialMessageFormat.Format5,
+        StationNumber: 0x00,
+        NetworkNumber: 0x00,
+        PcNumber: 0xFF,
+        RequestDestinationModuleIoNumber: 0x03FF,
+        RequestDestinationModuleStationNumber: 0x00,
+        SelfStationNumber: 0x00,
+        MessageWait: 0x00));
+```
+
+### Serial option reference
+
+| Serial option | Meaning |
+|---|---|
+| `PortName` | Serial port name, such as `COM3` |
+| `BaudRate` | Configured baud rate |
+| `DataBits` | Configured data bits |
+| `Parity` | Configured serial parity |
+| `StopBits` | Configured stop bits |
+| `Handshake` | Configured hardware/software flow control |
+| `MessageFormat` | Serial MC message format: `Format1`, `Format4`, or `Format5` |
+| `StationNumber` | Target station number |
+| `NetworkNumber` | Target network number for `3C/4C` |
+| `PcNumber` | Target PC number |
+| `RequestDestinationModuleIoNumber` | Request destination module I/O number for `4C` routing |
+| `RequestDestinationModuleStationNumber` | Request destination module station number for `4C` routing |
+| `SelfStationNumber` | Self-station number for multidrop layouts |
+| `MessageWait` | Serial message wait in 10 ms units |
+| `ReadBufferSize` / `WriteBufferSize` | Serial driver buffer sizing |
+| `NewLine` | Newline sequence used by line-oriented serial modes |
+
+### Default route
+
+For direct own-station CPU access:
+
+```csharp
+var route = MitsubishiRoute.Default;
+```
+
+For routed access, supply explicit route values:
+
+```csharp
+var route = new MitsubishiRoute(
+    NetworkNumber: 0x00,
+    StationNumber: 0xFF,
+    ModuleIoNumber: 0x03FF,
+    MultidropStationNumber: 0x00);
+```
+
+---
+
+## Creating the client
+
+```csharp
+using MitsubishiRx;
+
+await using var client = new MitsubishiRx.MitsubishiRx(options);
+```
+
+### Legacy constructor
+
+A compatibility constructor is also available:
+
+```csharp
+var client = new MitsubishiRx.MitsubishiRx(CpuType.QnA, "192.168.0.10", 5000, timeout: 1500);
+```
+
+---
+
+## Connection lifecycle
+
+### Open / close
+
+```csharp
+var open = await client.OpenAsync();
+if (!open.IsSucceed)
 {
-    static void Main()
-    {
-        // Initialize the PLC driver
-        var plc = new MitsubishiPlc("192.168.0.100", MitsubishiProtocolType.MCProtocol);
-        
-        // Connect to the PLC
-        plc.Connect();
+    Console.WriteLine(open.Err);
+}
 
-        // Read data from a device
-        var data = plc.ReadDevice("D100");
-        Console.WriteLine($"Value of D100: {data}");
+var close = await client.CloseAsync();
+```
 
-        // Write data to a device
-        plc.WriteDevice("D100", 123);
-        Console.WriteLine("Value written to D100.");
+Synchronous wrappers are also available:
 
-        // Disconnect from the PLC
-        plc.Disconnect();
-    }
+```csharp
+var openSync = client.Open();
+var closeSync = client.Close();
+```
+
+### Connection state stream
+
+```csharp
+using var states = client.ConnectionStates.Subscribe(state =>
+{
+    Console.WriteLine($"Connection state: {state}");
+});
+```
+
+Possible values:
+- `Disconnected`
+- `Connecting`
+- `Connected`
+- `Reconnecting`
+- `Faulted`
+
+---
+
+## Feature guide: every public operation
+
+The sections below map directly to the client’s public API.
+
+---
+
+## 1. Batch word reads and writes
+
+### Read words by PLC address
+
+```csharp
+var result = await client.ReadWordsAsync("D100", 2);
+if (result.IsSucceed)
+{
+    ushort d100 = result.Value![0];
+    ushort d101 = result.Value[1];
 }
 ```
 
-## Reactive Example
+### Read words over serial MC protocol
 
-```C#
-using System;
-using System.Reactive.Linq;
+```csharp
 using MitsubishiRx;
+using System.IO.Ports;
 
-class Program
+var serialOptions = new MitsubishiClientOptions(
+    Host: "COM3",
+    Port: 0,
+    FrameType: MitsubishiFrameType.FourC,
+    DataCode: CommunicationDataCode.Binary,
+    TransportKind: MitsubishiTransportKind.Serial,
+    Timeout: TimeSpan.FromSeconds(2),
+    CpuType: CpuType.Fx5,
+    Serial: new MitsubishiSerialOptions(
+        PortName: "COM3",
+        BaudRate: 9600,
+        DataBits: 7,
+        Parity: Parity.Even,
+        StopBits: StopBits.One,
+        Handshake: Handshake.None,
+        MessageFormat: MitsubishiSerialMessageFormat.Format5));
+
+await using var serialClient = new MitsubishiRx.MitsubishiRx(serialOptions);
+var serialRead = await serialClient.ReadWordsAsync("D100", 2);
+```
+
+### Write words by PLC address
+
+```csharp
+var write = await client.WriteWordsAsync("D100", new ushort[] { 123, 456, 789 });
+```
+
+### When to use
+- data registers like `D`, `W`, `R`, `ZR`
+- word-based timer/counter values like `TN`, `CN`, `SD`
+- bulk register transfers
+
+### PLC family guidance
+- **1E**: use for legacy-compatible batch device operations over Ethernet
+- **3E/4E**: preferred path for modern Ethernet PLCs
+- **1C/3C/4C**: use when the installed connection is serial MC protocol rather than Ethernet
+
+### Serial support status
+
+Current serial implementation status:
+
+| Serial area | Status |
+|---|---|
+| Reactive serial transport via `SerialPortRx` | **Implemented** |
+| Serial frame modeling (`1C`, `3C`, `4C`) | **Implemented** |
+| Serial option/configuration surface | **Implemented** |
+| Batch word read over serial | **Implemented** |
+| `1C` ASCII format 1/4 decode path | **Implemented** |
+| `3C` ASCII format 1/4 decode path | **Implemented** |
+| `4C` ASCII and binary format 5 decode path | **Implemented** |
+| Serial writes / random / block / monitor / remote control / memory operations | **Not yet implemented** |
+| Raw serial command execution | **Not yet implemented** |
+
+---
+
+## 2. Batch bit reads and writes
+
+### Read bits by PLC address
+
+```csharp
+var bits = await client.ReadBitsAsync("M10", 8);
+if (bits.IsSucceed)
 {
-    static void Main()
+    bool m10 = bits.Value![0];
+    bool m11 = bits.Value[1];
+}
+```
+
+### Write bits by PLC address
+
+```csharp
+var writeBits = await client.WriteBitsAsync("M10", new[] { true, false, true, true });
+```
+
+### Common device examples
+- `M` internal relays
+- `X` inputs
+- `Y` outputs
+- `L`, `SM`, `TS`, `TC`, `CS`, `CC`
+
+### X/Y notation example
+
+```csharp
+var octalOptions = options with { XyNotation = XyAddressNotation.Octal };
+var hexOptions = options with { XyNotation = XyAddressNotation.Hexadecimal };
+```
+
+---
+
+## 3. Random reads and writes
+
+Use random operations when you need non-contiguous word devices.
+
+### Random read words
+
+```csharp
+var randomRead = await client.RandomReadWordsAsync(new[]
+{
+    "D100",
+    "D250",
+    "W10",
+    "ZR200",
+});
+```
+
+### Random write words
+
+```csharp
+var randomWrite = await client.RandomWriteWordsAsync(new Dictionary<string, ushort>
+{
+    ["D100"] = 100,
+    ["D250"] = 250,
+    ["W10"] = 0x1234,
+});
+```
+
+### Best fit
+- sparse register collection
+- HMI/status pages pulling scattered registers
+- writing a small set of independent values without multiple round-trips
+
+---
+
+## 4. Monitor registration and monitor execution
+
+Monitoring is a two-stage operation.
+
+### Register monitor devices
+
+```csharp
+var register = await client.RegisterMonitorAsync(new[]
+{
+    "D100",
+    "D101",
+    "D102",
+});
+```
+
+### Execute monitor
+
+```csharp
+var monitor = await client.ExecuteMonitorAsync();
+if (monitor.IsSucceed)
+{
+    byte[] rawMonitorPayload = monitor.Value!;
+}
+```
+
+### Best fit
+- repeated observation of a fixed register list
+- lightweight monitoring loops coordinated by your application
+
+---
+
+## 5. Multiple block read and write
+
+Use block operations when you want grouped contiguous word and/or bit blocks.
+
+### Read blocks
+
+```csharp
+var blockRequest = new MitsubishiBlockRequest(
+    WordBlocks:
+    [
+        new MitsubishiWordBlock(MitsubishiDeviceAddress.Parse("D100"), new ushort[10]),
+        new MitsubishiWordBlock(MitsubishiDeviceAddress.Parse("W20", XyAddressNotation.Octal), new ushort[4]),
+    ],
+    BitBlocks:
+    [
+        new MitsubishiBitBlock(MitsubishiDeviceAddress.Parse("M10"), new bool[16]),
+    ]);
+
+var blockRead = await client.ReadBlocksAsync(blockRequest);
+```
+
+### Write blocks
+
+```csharp
+var writeRequest = new MitsubishiBlockRequest(
+    WordBlocks:
+    [
+        new MitsubishiWordBlock(MitsubishiDeviceAddress.Parse("D100"), new ushort[] { 1, 2, 3, 4 }),
+    ],
+    BitBlocks:
+    [
+        new MitsubishiBitBlock(MitsubishiDeviceAddress.Parse("M10"), new[] { true, false, true, false }),
+    ]);
+
+var blockWrite = await client.WriteBlocksAsync(writeRequest);
+```
+
+### Best fit
+- grouped transfer plans
+- deterministic read/write structures
+- coalesced data exchange where address continuity matters
+
+---
+
+## 6. PLC type-name read
+
+```csharp
+var typeName = await client.ReadTypeNameAsync();
+if (typeName.IsSucceed)
+{
+    Console.WriteLine(typeName.Value!.ModelName);
+    Console.WriteLine(typeName.Value.ModelCode);
+}
+```
+
+### Best fit
+- startup diagnostics
+- logging exact connected PLC/module type
+- validation that the integration is pointing at the expected target
+
+---
+
+## 7. Remote control operations
+
+### Remote RUN
+
+```csharp
+await client.RemoteRunAsync(force: true, clearMode: false);
+```
+
+### Remote STOP / PAUSE / RESET / LATCH CLEAR
+
+```csharp
+await client.RemoteStopAsync();
+await client.RemotePauseAsync();
+await client.RemoteResetAsync();
+await client.RemoteLatchClearAsync();
+```
+
+### Notes
+- available behavior depends on PLC family, CPU mode, permissions, and Ethernet module configuration
+- use carefully in production systems
+
+---
+
+## 8. Remote password unlock / lock
+
+```csharp
+await client.UnlockAsync("1234");
+await client.LockAsync("1234");
+```
+
+### Best fit
+- workflows where protected remote operations must be explicitly unlocked
+
+---
+
+## 9. Clear error
+
+```csharp
+var clear = await client.ClearErrorAsync();
+```
+
+### Best fit
+- acknowledging module/PLC error conditions after diagnostic handling
+
+---
+
+## 10. Loopback
+
+```csharp
+var loop = await client.LoopbackAsync(new byte[] { 0x12, 0x34, 0x56, 0x78 });
+if (loop.IsSucceed)
+{
+    var echoed = loop.Value!;
+}
+```
+
+### Best fit
+- link validation
+- protocol path smoke tests
+- troubleshooting Ethernet routes or gateway behavior
+
+---
+
+## 11. Memory read / write and intelligent-module access
+
+These methods expose raw memory/buffer style commands.
+
+### Memory read
+
+```csharp
+var memory = await client.ReadMemoryAsync(MitsubishiCommands.MemoryRead, address: 0x2000, length: 4);
+```
+
+### Memory write
+
+```csharp
+var memoryWrite = await client.WriteMemoryAsync(MitsubishiCommands.MemoryWrite, address: 0x2000, values: new ushort[] { 1, 2, 3, 4 });
+```
+
+### Extend unit read/write
+
+```csharp
+var unitRead = await client.ReadMemoryAsync(MitsubishiCommands.ExtendUnitRead, address: 0x0100, length: 8);
+var unitWrite = await client.WriteMemoryAsync(MitsubishiCommands.ExtendUnitWrite, address: 0x0100, values: new ushort[] { 10, 20, 30 });
+```
+
+### Best fit
+- intelligent function module buffer memory access
+- lower-level system data exchange where documented by Mitsubishi manuals
+
+---
+
+## 12. Raw command execution
+
+For advanced or unsupported workflows, execute a raw request.
+
+```csharp
+var raw = await client.ExecuteRawAsync(
+    new MitsubishiRawCommandRequest(
+        Command: MitsubishiCommands.DeviceRead,
+        Subcommand: 0x0000,
+        Body: Array.Empty<byte>(),
+        Description: "Custom raw op"));
+```
+
+### Best fit
+- experimental protocol work
+- custom command shapes
+- validating edge-case protocol scenarios
+
+---
+
+## 13. Reactive polling and diagnostics
+
+Reactive features are built with **ReactiveUI.Extensions**.
+
+### Observe words
+
+```csharp
+using var subscription = client
+    .ObserveWords("D100", 2, TimeSpan.FromSeconds(1))
+    .Subscribe(result =>
     {
-        // Initialize the PLC driver
-        var plc = new MitsubishiPlc("192.168.0.100", MitsubishiProtocolType.MCProtocol);
-
-        // Connect to the PLC
-        plc.Connect();
-
-        // Observe changes on a specific device
-        var deviceObservable = plc.Observe("D100");
-
-        // Subscribe to the observable to react to changes
-        var subscription = deviceObservable.Subscribe(value =>
+        if (result.IsSucceed)
         {
-            Console.WriteLine($"D100 changed to: {value}");
-        });
+            Console.WriteLine(string.Join(", ", result.Value!));
+        }
+    });
+```
 
-        // Simulate a delay for demonstration purposes
-        Console.WriteLine("Observing changes. Press any key to stop...");
-        Console.ReadKey();
+### Observe bits
 
-        // Dispose of the subscription and disconnect
-        subscription.Dispose();
-        plc.Disconnect();
-    }
+```csharp
+using var bitSubscription = client
+    .ObserveBits("M10", 8, TimeSpan.FromMilliseconds(500))
+    .Subscribe(result =>
+    {
+        if (result.IsSucceed)
+        {
+            Console.WriteLine(string.Join(", ", result.Value!));
+        }
+    });
+```
+
+### Observe words with heartbeat
+
+```csharp
+using var heartbeatSub = client
+    .ObserveWordsHeartbeat(
+        "D100",
+        2,
+        pollInterval: TimeSpan.FromSeconds(1),
+        heartbeatAfter: TimeSpan.FromSeconds(2))
+    .Subscribe(sample =>
+    {
+        if (sample.IsHeartbeat)
+        {
+            Console.WriteLine("Heartbeat");
+            return;
+        }
+
+        Console.WriteLine(string.Join(", ", sample.Update.Value!));
+    });
+```
+
+### Observe words with stale detection
+
+```csharp
+using var staleSub = client
+    .ObserveWordsStale(
+        "D100",
+        2,
+        pollInterval: TimeSpan.FromSeconds(1),
+        staleAfter: TimeSpan.FromSeconds(5))
+    .Subscribe(state =>
+    {
+        Console.WriteLine($"Is stale: {state.IsStale}");
+    });
+```
+
+### Triggered latest-only reads
+
+```csharp
+using System.Reactive;
+using System.Reactive.Subjects;
+
+var trigger = new Subject<Unit>();
+using var latestSub = client
+    .ObserveWordsLatest("D100", 2, trigger)
+    .Subscribe(result => Console.WriteLine(result.IsSucceed));
+
+trigger.OnNext(Unit.Default);
+```
+
+### Reactive tag-group polling
+
+Once tag groups are defined, you can observe grouped snapshots with the same reactive patterns used by the lower-level word/bit APIs.
+
+### Observe a tag group
+
+```csharp
+using var groupSub = client
+    .ObserveTagGroup("Line1Overview", TimeSpan.FromSeconds(1))
+    .Subscribe(result =>
+    {
+        if (!result.IsSucceed || result.Value is null)
+        {
+            return;
+        }
+
+        var snapshot = result.Value;
+        Console.WriteLine($"Temp={snapshot.GetRequired<short>("SignedTemp")}");
+        Console.WriteLine($"Count={snapshot.GetRequired<uint>("TotalCount")}");
+        Console.WriteLine($"Message={snapshot.GetRequired<string>("OperatorMessage")}");
+        Console.WriteLine($"Pump={snapshot.GetRequired<bool>("PumpRunning")}");
+    });
+```
+
+### Observe a tag group with heartbeat
+
+```csharp
+using var groupHeartbeat = client
+    .ObserveTagGroupHeartbeat(
+        "Line1Overview",
+        pollInterval: TimeSpan.FromSeconds(5),
+        heartbeatAfter: TimeSpan.FromSeconds(2))
+    .Subscribe(sample =>
+    {
+        if (sample.IsHeartbeat)
+        {
+            Console.WriteLine("Group heartbeat");
+            return;
+        }
+
+        var snapshot = sample.Update!.Value!;
+        Console.WriteLine(snapshot.GetRequired<uint>("TotalCount"));
+    });
+```
+
+### Observe a tag group with stale detection
+
+```csharp
+using var groupStale = client
+    .ObserveTagGroupStale(
+        "Line1Overview",
+        pollInterval: TimeSpan.FromSeconds(5),
+        staleAfter: TimeSpan.FromSeconds(2))
+    .Subscribe(state =>
+    {
+        Console.WriteLine($"Group stale={state.IsStale}");
+    });
+```
+
+### Triggered latest-only grouped reads
+
+```csharp
+using System.Reactive;
+using System.Reactive.Subjects;
+
+var groupTrigger = new Subject<Unit>();
+using var latestGroup = client
+    .ObserveTagGroupLatest("Line1Overview", groupTrigger)
+    .Subscribe(result =>
+    {
+        if (result.IsSucceed && result.Value is not null)
+        {
+            Console.WriteLine(result.Value.GetRequired<uint>("TotalCount"));
+        }
+    });
+
+groupTrigger.OnNext(Unit.Default);
+```
+
+These grouped reactive APIs are useful for HMI/dashboard polling loops because they keep the application written against stable symbolic names instead of raw PLC addresses.
+
+### Operation logs and sampled diagnostics
+
+```csharp
+using var logs = client.OperationLogs.Subscribe(log =>
+{
+    Console.WriteLine($"{log.TimestampUtc:u} {log.Description} success={log.Success}");
+});
+```
+
+```csharp
+using System.Reactive.Linq;
+
+var diagnosticTrigger = Observable.Interval(TimeSpan.FromSeconds(2)).Select(_ => new object());
+using var diagnostics = client.SampleDiagnostics(diagnosticTrigger).Subscribe(log =>
+{
+    Console.WriteLine(log.Description);
+});
+```
+
+### Connection health
+
+```csharp
+using var health = client.ObserveConnectionHealth(TimeSpan.FromSeconds(10)).Subscribe(state =>
+{
+    Console.WriteLine($"Connection stale={state.IsStale}, state={state.Update}");
+});
+```
+
+### Reactive operators used internally
+
+The library meaningfully uses these `ReactiveUI.Extensions` operators:
+- `RetryWithBackoff(...)`
+- `SelectAsyncSequential(...)`
+- `SelectLatestAsync(...)`
+- `Heartbeat(...)`
+- `DetectStale(...)`
+- `Conflate(...)`
+- `SampleLatest(...)`
+- `DoOnSubscribe(...)`
+- `DoOnDispose(...)`
+
+---
+
+## Tag database: use tag names instead of PLC addresses
+
+For production applications, raw addresses like `D100` and `M10` usually belong in configuration, not code.
+
+The library now includes an in-memory **tag database** that maps symbolic names to PLC addresses.
+
+### What it gives you
+
+Instead of this:
+
+```csharp
+var speed = await client.ReadWordsAsync("D100", 2);
+var pump = await client.ReadBitsAsync("M10", 1);
+await client.WriteWordsAsync("D300", new ushort[] { 12 });
+await client.RandomWriteWordsAsync(new[]
+{
+    new KeyValuePair<string, ushort>("D500", 100),
+    new KeyValuePair<string, ushort>("D501", 200),
+});
+```
+
+you can do this:
+
+```csharp
+var speed = await client.ReadWordsByTagAsync("MotorSpeed", 2);
+var pump = await client.ReadBitsByTagAsync("PumpRunning", 1);
+await client.WriteWordsByTagAsync("RecipeNumber", new ushort[] { 12 });
+await client.RandomWriteWordsByTagAsync(new[]
+{
+    new KeyValuePair<string, ushort>("RecipeSetpointA", 100),
+    new KeyValuePair<string, ushort>("RecipeSetpointB", 200),
+});
+```
+
+### Tag database types
+
+- `MitsubishiTagDefinition`
+- `MitsubishiTagDatabase`
+- `MitsubishiTagGroupDefinition`
+- `MitsubishiTagGroupSnapshot`
+- `MitsubishiRx.TagDatabase`
+- `ReadWordsByTagAsync(...)`
+- `ReadBitsByTagAsync(...)`
+- `WriteWordsByTagAsync(...)`
+- `WriteBitsByTagAsync(...)`
+- `RandomReadWordsByTagAsync(...)`
+- `RandomWriteWordsByTagAsync(...)`
+- `ReadInt16ByTagAsync(...)`
+- `WriteInt16ByTagAsync(...)`
+- `ReadUInt16ByTagAsync(...)`
+- `WriteUInt16ByTagAsync(...)`
+- `ReadInt32ByTagAsync(...)`
+- `WriteInt32ByTagAsync(...)`
+- `ReadDWordByTagAsync(...)`
+- `WriteDWordByTagAsync(...)`
+- `ReadFloatByTagAsync(...)`
+- `WriteFloatByTagAsync(...)`
+- `ReadScaledDoubleByTagAsync(...)`
+- `WriteScaledDoubleByTagAsync(...)`
+- `ReadStringByTagAsync(...)`
+- `WriteStringByTagAsync(...)`
+- `ValidateTagDatabase()`
+- `ReadTagGroupSnapshotAsync(...)`
+
+### Build a tag database in code
+
+```csharp
+using MitsubishiRx;
+
+var tags = new MitsubishiTagDatabase(new[]
+{
+    new MitsubishiTagDefinition(
+        Name: "MotorSpeed",
+        Address: "D100",
+        DataType: "Word",
+        Description: "Main spindle RPM",
+        Scale: 0.1,
+        Offset: 0.0,
+        Notes: "Engineering scaling 0.1 RPM per count"),
+
+    new MitsubishiTagDefinition(
+        Name: "PumpRunning",
+        Address: "M10",
+        DataType: "Bit",
+        Description: "Coolant pump running"),
+
+    new MitsubishiTagDefinition(
+        Name: "RecipeNumber",
+        Address: "D300",
+        DataType: "Word",
+        Description: "Selected recipe number"),
+
+    new MitsubishiTagDefinition(
+        Name: "RecipeSetpointA",
+        Address: "D500",
+        DataType: "Word"),
+
+    new MitsubishiTagDefinition(
+        Name: "RecipeSetpointB",
+        Address: "D501",
+        DataType: "Word"),
+});
+
+client.TagDatabase = tags;
+```
+
+### Read and write using tag names
+
+```csharp
+var speed = await client.ReadWordsByTagAsync("MotorSpeed", 2);
+var running = await client.ReadBitsByTagAsync("PumpRunning", 1);
+
+await client.WriteWordsByTagAsync("RecipeNumber", new ushort[] { 12 });
+await client.WriteBitsByTagAsync("PumpRunning", new[] { true });
+```
+
+### Random operations using tag names
+
+```csharp
+var recipeValues = await client.RandomReadWordsByTagAsync(new[]
+{
+    "RecipeSetpointA",
+    "RecipeSetpointB",
+    "RecipeNumber",
+});
+
+await client.RandomWriteWordsByTagAsync(new[]
+{
+    new KeyValuePair<string, ushort>("RecipeSetpointA", 100),
+    new KeyValuePair<string, ushort>("RecipeSetpointB", 200),
+    new KeyValuePair<string, ushort>("RecipeNumber", 12),
+});
+```
+
+### Typed tag helpers
+
+Use `DataType` to make tag intent explicit and then call the typed helpers directly.
+
+```csharp
+var signedTemp = await client.ReadInt16ByTagAsync("SignedTemp");
+await client.WriteInt16ByTagAsync("SignedTemp", -100);
+
+var wordValue = await client.ReadUInt16ByTagAsync("RecipeNumber");
+await client.WriteUInt16ByTagAsync("RecipeNumber", 12);
+
+var signedTotal = await client.ReadInt32ByTagAsync("SignedTotal");
+await client.WriteInt32ByTagAsync("SignedTotal", 123456);
+
+var totalCount = await client.ReadDWordByTagAsync("TotalCount");
+await client.WriteDWordByTagAsync("TotalCount", 123456u);
+
+var processValue = await client.ReadFloatByTagAsync("ProcessValue");
+await client.WriteFloatByTagAsync("ProcessValue", 12.5f);
+```
+
+Integer helpers supported in the current API surface:
+- `ReadInt16ByTagAsync(...)`
+- `WriteInt16ByTagAsync(...)`
+- `ReadUInt16ByTagAsync(...)`
+- `WriteUInt16ByTagAsync(...)`
+- `ReadInt32ByTagAsync(...)`
+- `WriteInt32ByTagAsync(...)`
+- `ReadDWordByTagAsync(...)`
+- `WriteDWordByTagAsync(...)`
+- `ReadFloatByTagAsync(...)`
+- `WriteFloatByTagAsync(...)`
+
+`Int32`, `UInt32`/`DWord`, and `Float` values are encoded across two Mitsubishi words. `ByteOrder` controls whether those two words are interpreted as `LittleEndian` or `BigEndian`.
+
+### Scaled engineering values
+
+If a tag carries engineering metadata in `Scale` and `Offset`, use the scaled helpers so application code can work with engineering units instead of raw PLC counts.
+
+```csharp
+var headTemp = await client.ReadScaledDoubleByTagAsync("HeadTemp");
+await client.WriteScaledDoubleByTagAsync("HeadTemp", 15.0d);
+```
+
+With this CSV row:
+
+```csv
+Name,Address,DataType,Scale,Offset
+HeadTemp,D200,Word,0.1,-10
+```
+
+the PLC raw value `250` becomes `(250 * 0.1) + (-10) = 15.0`.
+
+Scaled read/write currently supports:
+- `Word`
+- `DWord`
+- `Float`
+
+### PLC strings using tag names
+
+For PLC text stored in word registers, use the string helpers with an explicit word length or let the tag schema provide it.
+
+```csharp
+var message = await client.ReadStringByTagAsync("OperatorMessage", wordLength: 8);
+await client.WriteStringByTagAsync("OperatorMessage", "READY", wordLength: 8);
+
+var schemaDrivenMessage = await client.ReadStringByTagAsync("Utf8Message");
+await client.WriteStringByTagAsync("Utf8Message", "Aé");
+```
+
+String values are packed into successive words using the configured `Encoding`. Each Mitsubishi word stores two bytes, and `ByteOrder` controls how those two bytes are packed inside each word.
+
+### How tag resolution works
+
+- tag names are resolved case-insensitively
+- the resolved tag supplies the PLC `Address`
+- `DataType` is validated when tags are added or imported from CSV
+- supported `DataType` values are:
+  - `Bit`
+  - `Word`
+  - `DWord`
+  - `Float`
+  - `String`
+- `DataType` matching is case-insensitive and normalized to the canonical values above
+- the current tag-based convenience API supports:
+  - `ReadWordsByTagAsync(...)`
+  - `ReadBitsByTagAsync(...)`
+  - `WriteWordsByTagAsync(...)`
+  - `WriteBitsByTagAsync(...)`
+  - `RandomReadWordsByTagAsync(...)`
+  - `RandomWriteWordsByTagAsync(...)`
+  - `ReadDWordByTagAsync(...)`
+  - `WriteDWordByTagAsync(...)`
+  - `ReadFloatByTagAsync(...)`
+  - `WriteFloatByTagAsync(...)`
+  - `ReadScaledDoubleByTagAsync(...)`
+  - `WriteScaledDoubleByTagAsync(...)`
+  - `ReadStringByTagAsync(...)`
+  - `WriteStringByTagAsync(...)`
+- tag APIs are transport/frame agnostic: they work with `1E`, `3E`, `4E`, `TCP`, `UDP`, `Binary`, and `Ascii` wherever the underlying operation is supported by the target PLC family/module
+- all tag APIs eventually resolve to the same raw address-based methods, so protocol behavior stays identical after resolution
+- other operations can still use the same database manually:
+
+```csharp
+var tag = client.TagDatabase!.GetRequired("RecipeSetpointA");
+await client.WriteWordsAsync(tag.Address, new ushort[] { 2500 });
+```
+
+### Recommended usage model
+
+- store PLC addressing in CSV/configuration
+- load it at application startup
+- assign it to `client.TagDatabase`
+- keep application logic written against stable tag names
+- let maintenance teams change addresses in CSV without changing application code
+- define `MitsubishiTagGroupDefinition` scan classes for common screens, loops, and reporting views
+- call `ValidateTagDatabase()` during startup so bad addresses, missing string lengths, and broken group references fail fast
+
+### Tag groups and grouped snapshots
+
+For higher-level workflows, define named groups of tags and read them as a single heterogeneous snapshot.
+
+```csharp
+var tags = MitsubishiTagDatabase.FromCsv(File.ReadAllText("plc-tags.csv"));
+
+tags.AddGroup(new MitsubishiTagGroupDefinition(
+    Name: "Line1Overview",
+    TagNames: new[]
+    {
+        "SignedTemp",
+        "TotalCount",
+        "OperatorMessage",
+        "PumpRunning",
+    }));
+
+tags.AddGroup(new MitsubishiTagGroupDefinition(
+    Name: "RecipeWrite",
+    TagNames: new[]
+    {
+        "RecipeNumber",
+        "OperatorMessage",
+    }));
+
+client.TagDatabase = tags;
+
+var validation = client.ValidateTagDatabase();
+if (!validation.IsSucceed)
+{
+    throw new InvalidOperationException(validation.Err);
+}
+
+var snapshot = await client.ReadTagGroupSnapshotAsync("Line1Overview");
+
+var signedTemp = snapshot.Value!.GetRequired<short>("SignedTemp");
+var totalCount = snapshot.Value.GetRequired<uint>("TotalCount");
+var operatorMessage = snapshot.Value.GetRequired<string>("OperatorMessage");
+var pumpRunning = snapshot.Value.GetRequired<bool>("PumpRunning");
+```
+
+Use tag groups when you want:
+- startup validation of known screen/report/scan-class dependencies
+- a single named collection for related tags
+- typed access to heterogeneous values without scattering tag names across the application
+
+### Grouped writes and setpoint commits
+
+For HMI/setpoint workflows, validate and write only the values you want to commit.
+
+```csharp
+var pendingValues = new Dictionary<string, object?>
+{
+    ["RecipeNumber"] = (ushort)7,
+    ["OperatorMessage"] = "OK!",
+};
+
+var writeValidation = client.ValidateTagGroupWrite("RecipeWrite", pendingValues);
+if (!writeValidation.IsSucceed)
+{
+    throw new InvalidOperationException(writeValidation.Err);
+}
+
+await client.WriteTagGroupValuesAsync("RecipeWrite", pendingValues);
+```
+
+You can also write a full grouped snapshot directly:
+
+```csharp
+var writeSnapshot = new MitsubishiTagGroupSnapshot(
+    "Line1Overview",
+    new Dictionary<string, object?>
+    {
+        ["SignedTemp"] = (short)-100,
+        ["TotalCount"] = 0x12345678u,
+        ["OperatorMessage"] = "OK!",
+    });
+
+await client.WriteTagGroupSnapshotAsync(writeSnapshot);
+```
+
+`ValidateTagGroupWrite(...)` reports:
+- values whose CLR types do not match the target tag schema
+- values for tags that are not part of the named group
+- the same underlying tag/schema issues already enforced by the individual tag helpers
+
+---
+
+## CSV import: initialize the tag database from a file
+
+You can initialize the tag database directly from CSV.
+
+### Supported required/optional columns
+
+| Column | Required | Meaning |
+|---|---|---|
+| `Name` | **Yes** | Unique symbolic tag name used by application code |
+| `Address` | **Yes** | Mitsubishi PLC address such as `D100`, `M10`, `X20`, `ZR200` |
+| `DataType` | No | Type hint such as `Bit`, `Word`, `DWord`, `Float`, `String`, `Int16`, `UInt16`, `Int32`, `UInt32` |
+| `Description` | No | Human-readable description |
+| `Scale` | No | Engineering scale factor, default `1.0` |
+| `Offset` | No | Engineering offset, default `0.0` |
+| `Length` | No | Logical tag length in PLC words, mainly used by string tags and fixed-width layouts |
+| `Encoding` | No | Text encoding hint such as `Ascii`, `Utf8`, or `Utf16` |
+| `Units` | No | Engineering units label such as `rpm`, `°C`, or `items` |
+| `Signed` | No | Boolean signedness hint for integer word/double-word tags, default `false` |
+| `ByteOrder` | No | Multi-word and string packing order: `LittleEndian` or `BigEndian` |
+| `Notes` | No | Free-form notes |
+
+### Required CSV formatting
+
+- first row **must** be a header row
+- at minimum the header must include:
+  - `Name`
+  - `Address`
+- column names are matched case-insensitively
+- blank lines are ignored
+- quoted CSV fields are supported
+- embedded double quotes inside quoted fields should be escaped as `""`
+- numeric `Scale`, `Offset`, and `Length` values should use invariant-culture formatting
+- `Signed` should be `true` or `false`
+- do **not** include engineering units inside `Scale` or `Offset`
+- `Address` must contain a valid Mitsubishi device address string usable by the client
+- if `DataType` is supplied it must be one of:
+  - `Bit`
+  - `Word`
+  - `DWord`
+  - `Float`
+  - `String`
+  - `Int16`
+  - `UInt16`
+  - `Int32`
+  - `UInt32`
+- if `Encoding` is supplied it must be one of:
+  - `Ascii`
+  - `Utf8`
+  - `Utf16`
+- if `ByteOrder` is supplied it must be one of:
+  - `LittleEndian`
+  - `BigEndian`
+- `DataType`, `Encoding`, and `ByteOrder` matching is case-insensitive when imported, but stored in canonical form
+- use one logical PLC item per CSV row
+- keep `Name` unique across the file so it can be used safely as the application lookup key
+
+### Example CSV file
+
+```csv
+Name,Address,DataType,Description,Scale,Offset,Length,Encoding,Units,Signed,ByteOrder,Notes
+MotorSpeed,D100,Word,Main spindle RPM,0.1,0,,,rpm,false,,From commissioning sheet
+PumpRunning,M10,Bit,Coolant pump running,1,0,,,,false,,
+HeadTemp,D200,Word,Head temperature,0.1,-10,,,°C,true,,Signed engineering temperature tag
+RecipeNumber,D300,UInt16,Selected recipe,1,0,,,recipe,false,,
+TotalCount,D400,UInt32,Accumulated production count,1,0,,,items,false,LittleEndian,32-bit unsigned counter
+ProcessValue,D500,Float,Engineering process value,1,0,,,bar,false,LittleEndian,IEEE754 single precision across two words
+OperatorMessage,D600,String,Operator status message,1,0,8,Ascii,,false,LittleEndian,Packed text in word registers
+SignedTemp,D700,Int16,Signed temperature raw count,1,0,,,counts,true,,Two's complement 16-bit value
+SignedTotal,D710,Int32,Signed accumulated count,1,0,,,items,true,BigEndian,Big-endian multiword example
+Utf8Message,D720,String,UTF-8 operator text,1,0,2,Utf8,,false,LittleEndian,Schema-driven string length
+ServoReady,M100,Bit,Servo ready,1,0,,,,false,,
+XAxisLimit,X20,Bit,X-axis forward limit,1,0,,,,false,,X uses configured XyNotation
+ZoneRegister,ZR200,Word,Zone parameter register,1,0,,,,false,,
+```
+
+### Load from a CSV string
+
+```csharp
+var csv = File.ReadAllText("plc-tags.csv");
+var tagDatabase = MitsubishiTagDatabase.FromCsv(csv);
+client.TagDatabase = tagDatabase;
+```
+
+Or load the same CSV directly by file extension:
+
+```csharp
+client.TagDatabase = MitsubishiTagDatabase.Load("plc-tags.csv");
+```
+
+### Full startup example
+
+```csharp
+using MitsubishiRx;
+
+var options = new MitsubishiClientOptions(
+    Host: "192.168.0.10",
+    Port: 5000,
+    FrameType: MitsubishiFrameType.ThreeE,
+    DataCode: CommunicationDataCode.Binary,
+    TransportKind: MitsubishiTransportKind.Tcp,
+    Route: MitsubishiRoute.Default,
+    MonitoringTimer: 0x0010,
+    XyNotation: XyAddressNotation.Octal);
+
+var csv = File.ReadAllText("plc-tags.csv");
+var tags = MitsubishiTagDatabase.FromCsv(csv);
+
+await using var client = new MitsubishiRx.MitsubishiRx(options)
+{
+    TagDatabase = tags,
+};
+
+var speed = await client.ReadWordsByTagAsync("MotorSpeed", 2);
+var pump = await client.ReadBitsByTagAsync("PumpRunning", 1);
+await client.WriteUInt16ByTagAsync("RecipeNumber", 7);
+await client.RandomWriteWordsByTagAsync(new[]
+{
+    new KeyValuePair<string, ushort>("RecipeSetpointA", 100),
+    new KeyValuePair<string, ushort>("RecipeSetpointB", 200),
+});
+
+var signedTemp = await client.ReadInt16ByTagAsync("SignedTemp");
+var signedTotal = await client.ReadInt32ByTagAsync("SignedTotal");
+var totalCount = await client.ReadDWordByTagAsync("TotalCount");
+var processValue = await client.ReadFloatByTagAsync("ProcessValue");
+var engineeringTemp = await client.ReadScaledDoubleByTagAsync("HeadTemp");
+var operatorMessage = await client.ReadStringByTagAsync("OperatorMessage");
+var utf8Message = await client.ReadStringByTagAsync("Utf8Message");
+```
+
+### JSON and YAML schema workflows
+
+CSV is useful for spreadsheets and maintenance exports, but JSON/YAML are better when you want full schema persistence, groups, and richer version-controlled configuration.
+
+### Export the full schema to JSON
+
+```csharp
+client.TagDatabase!.Save("plc-tags.json");
+```
+
+Equivalent explicit form:
+
+```csharp
+var json = client.TagDatabase!.ToJson();
+File.WriteAllText("plc-tags.json", json);
+```
+
+### Load the full schema from JSON
+
+```csharp
+client.TagDatabase = MitsubishiTagDatabase.Load("plc-tags.json");
+```
+
+Equivalent explicit form:
+
+```csharp
+var json = File.ReadAllText("plc-tags.json");
+var tags = MitsubishiTagDatabase.FromJson(json);
+client.TagDatabase = tags;
+```
+
+### Export the full schema to YAML
+
+```csharp
+client.TagDatabase!.Save("plc-tags.yaml");
+client.TagDatabase!.Save("plc-tags.yml");
+```
+
+Equivalent explicit form:
+
+```csharp
+var yaml = client.TagDatabase!.ToYaml();
+File.WriteAllText("plc-tags.yaml", yaml);
+```
+
+### Load the full schema from YAML
+
+```csharp
+client.TagDatabase = MitsubishiTagDatabase.Load("plc-tags.yaml");
+client.TagDatabase = MitsubishiTagDatabase.Load("plc-tags.yml");
+```
+
+Equivalent explicit form:
+
+```csharp
+var yaml = File.ReadAllText("plc-tags.yaml");
+var tags = MitsubishiTagDatabase.FromYaml(yaml);
+client.TagDatabase = tags;
+```
+
+### Example YAML schema with groups
+
+```yaml
+tags:
+  - name: SignedTemp
+    address: D700
+    dataType: Int16
+    signed: true
+    units: °C
+  - name: OperatorMessage
+    address: D600
+    dataType: String
+    length: 2
+    encoding: Utf8
+    byteOrder: BigEndian
+groups:
+  - name: Overview
+    tagNames:
+      - SignedTemp
+      - OperatorMessage
+```
+
+Use JSON/YAML when you want:
+- full schema persistence including groups
+- easier code review of tag model changes in version control
+- richer metadata than a compact CSV worksheet usually carries
+
+Use `MitsubishiTagDatabase.Load(path)` / `Save(path)` when you want one-line startup configuration or persistence with automatic detection for `.csv`, `.json`, `.yaml`, and `.yml`.
+
+For commissioning workflows, `client.LoadAndValidateTagDatabase(path)` loads, validates, and applies the schema in one step, `client.PreviewTagDatabaseDiff(path)` shows what would change before you commit it, and `client.ObserveTagDatabaseReload(path, pollInterval)` / `client.ObserveTagDatabaseDiff(path, pollInterval)` provide reactive reload and audit streams. Use rollout policies when you want to allow metadata/group edits automatically while blocking address or datatype changes.
+
+### Load, validate, and apply a schema in one step
+
+```csharp
+var loadResult = client.LoadAndValidateTagDatabase("plc-tags.yaml");
+if (!loadResult.IsSucceed)
+{
+    throw new InvalidOperationException(loadResult.Err);
 }
 ```
 
-## Contributing
-Contributions are welcome! Please fork the repository and submit a pull request for review. Be sure to adhere to the contribution guidelines.
+### Reactively hot-reload a schema during commissioning
+
+```csharp
+using var schemaReload = client
+    .ObserveTagDatabaseReload("plc-tags.yaml", TimeSpan.FromSeconds(2))
+    .Subscribe(result =>
+    {
+        if (!result.IsSucceed)
+        {
+            Console.WriteLine($"Schema reload failed: {result.Err}");
+            return;
+        }
+
+        Console.WriteLine($"Reloaded {result.Value!.Count} tags and {result.Value.GroupCount} groups");
+    });
+```
+
+`ObserveTagDatabaseReload(...)` only applies a newly loaded database when validation succeeds. Invalid reloads are emitted as failed results and the last valid `client.TagDatabase` remains active.
+
+### Preview schema changes before applying them
+
+```csharp
+var preview = client.PreviewTagDatabaseDiff("plc-tags.yaml");
+if (!preview.IsSucceed)
+{
+    throw new InvalidOperationException(preview.Err);
+}
+
+Console.WriteLine($"Added tags: {preview.Value!.AddedTags.Count}");
+Console.WriteLine($"Removed tags: {preview.Value.RemovedTags.Count}");
+Console.WriteLine($"Changed tags: {preview.Value.ChangedTags.Count}");
+```
+
+### Reactively audit schema changes during hot reload
+
+```csharp
+using var schemaAudit = client
+    .ObserveTagDatabaseDiff("plc-tags.yaml", TimeSpan.FromSeconds(2), emitInitial: false)
+    .Subscribe(result =>
+    {
+        if (!result.IsSucceed)
+        {
+            Console.WriteLine($"Schema diff failed: {result.Err}");
+            return;
+        }
+
+        var diff = result.Value!;
+        Console.WriteLine($"Schema changed: {diff.ChangeCount} semantic changes");
+    });
+```
+
+`ObserveTagDatabaseDiff(...)` emits semantic tag/group changes for each successful reload and keeps the last valid `client.TagDatabase` when an update is invalid.
+
+### Apply rollout policy gates during commissioning
+
+```csharp
+var gatedLoad = client.LoadAndValidateTagDatabase(
+    "plc-tags.yaml",
+    MitsubishiTagRolloutPolicy.SafeMetadataAndGroups);
+
+if (!gatedLoad.IsSucceed)
+{
+    throw new InvalidOperationException(gatedLoad.Err);
+}
+```
+
+`MitsubishiTagRolloutPolicy.SafeMetadataAndGroups` allows:
+- metadata-only tag changes
+- tag-group membership/order changes
+
+It rejects:
+- address changes
+- datatype/encoding/length/signedness/byte-order changes
+- added/removed tags or groups
+
+### Preview classified changes before applying them
+
+```csharp
+var preview = client.PreviewTagDatabaseDiff(
+    "plc-tags.yaml",
+    MitsubishiTagRolloutPolicy.SafeMetadataAndGroups);
+
+if (preview.Value is not null)
+{
+    Console.WriteLine($"Kinds: {preview.Value.ChangeKinds}");
+    Console.WriteLine($"Total changes: {preview.Value.ChangeCount}");
+}
+```
+
+### Reactively enforce rollout policy during hot reload
+
+```csharp
+using var gatedReload = client
+    .ObserveTagDatabaseReload(
+        "plc-tags.yaml",
+        TimeSpan.FromSeconds(2),
+        emitInitial: false,
+        policy: MitsubishiTagRolloutPolicy.SafeMetadataAndGroups)
+    .Subscribe(result =>
+    {
+        if (!result.IsSucceed)
+        {
+            Console.WriteLine($"Reload blocked: {result.Err}");
+        }
+    });
+```
+
+### Practical CSV rules for maintenance teams
+
+Recommended conventions:
+- `Name`: PascalCase or a consistent SCADA/HMI-friendly convention
+- `Address`: exact Mitsubishi address string with no extra spaces
+- `DataType`: one of `Bit`, `Word`, `DWord`, `Float`, `String`, `Int16`, `UInt16`, `Int32`, `UInt32`
+- `Length`: set this for string tags so code can call `ReadStringByTagAsync(tagName)` without supplying a length each time
+- `Encoding`: use `Ascii` unless the PLC text really requires `Utf8` or `Utf16`
+- `Signed`: set to `true` for signed integer word/double-word values or signed scaled engineering values
+- `ByteOrder`: use `LittleEndian` for the normal two-word Mitsubishi layout and `BigEndian` only when the external data contract requires it
+- `Units`: use for UI/reporting metadata such as `rpm`, `°C`, or `items`
+- `Description`: operator-facing sentence
+- `Notes`: use for commissioning notes, source document, or unit conversion notes
+
+### Example with quoted fields
+
+```csv
+Name,Address,DataType,Description,Scale,Offset,Notes
+LineSpeed,D110,Word,"Main conveyor speed, calculated",0.01,0,"Imported from ""Line-1 IO List"""
+```
+
+### Validation behavior
+
+`MitsubishiTagDatabase.FromCsv(...)` will fail when:
+- there is no header row
+- `Name` is missing from the header
+- `Address` is missing from the header
+- a row has an empty required value for `Name` or `Address`
+- `Scale`, `Offset`, or `Length` contain invalid numeric values
+- `Signed` contains an invalid boolean value
+- `DataType` contains an unsupported value
+- `Encoding` contains an unsupported value
+- `ByteOrder` contains an unsupported value
+
+`client.ValidateTagDatabase()` additionally reports:
+- tag addresses that cannot be parsed for the configured `XyNotation`
+- string tags that do not define a positive `Length`
+- tag groups that reference missing tags
+
+The accepted `DataType` values are exactly:
+- `Bit`
+- `Word`
+- `DWord`
+- `Float`
+- `String`
+- `Int16`
+- `UInt16`
+- `Int32`
+- `UInt32`
+
+The accepted `Encoding` values are exactly:
+- `Ascii`
+- `Utf8`
+- `Utf16`
+
+The accepted `ByteOrder` values are exactly:
+- `LittleEndian`
+- `BigEndian`
+
+---
+
+## PLC-family-specific usage guidance
+
+This section shows how to think about feature usage by PLC family.
+
+### A / AnS legacy paths
+
+Use **1E** when the installed Ethernet interface/module exposes A-compatible MC protocol only.
+
+Typical operations:
+- `ReadWordsAsync`
+- `WriteWordsAsync`
+- `ReadBitsAsync`
+- `WriteBitsAsync`
+- `ReadTypeNameAsync`
+- `LoopbackAsync`
+- core remote operations where supported by the target path
+
+Example:
+
+```csharp
+var options = new MitsubishiClientOptions(
+    Host: "192.168.0.20",
+    Port: 5000,
+    FrameType: MitsubishiFrameType.OneE,
+    DataCode: CommunicationDataCode.Binary,
+    TransportKind: MitsubishiTransportKind.Tcp,
+    MonitoringTimer: 0x0010,
+    CpuType: CpuType.ASeries,
+    LegacyPcNumber: 0xFF);
+```
+
+### Q / QnA / L / iQ-R / iQ-F / FX5 modern Ethernet
+
+Use **3E** as the default unless the integration explicitly needs **4E** serial correlation.
+
+Typical operations:
+- all batch operations
+- random read/write
+- block read/write
+- monitor registration/execute
+- type-name read
+- remote control
+- password unlock/lock
+- memory and extend-unit access
+- TCP or UDP depending on endpoint configuration
+
+3E example:
+
+```csharp
+var options = new MitsubishiClientOptions(
+    Host: "192.168.0.30",
+    Port: 5000,
+    FrameType: MitsubishiFrameType.ThreeE,
+    DataCode: CommunicationDataCode.Binary,
+    TransportKind: MitsubishiTransportKind.Tcp,
+    Route: MitsubishiRoute.Default,
+    MonitoringTimer: 0x0010);
+```
+
+4E example:
+
+```csharp
+var options = new MitsubishiClientOptions(
+    Host: "192.168.0.31",
+    Port: 5000,
+    FrameType: MitsubishiFrameType.FourE,
+    DataCode: CommunicationDataCode.Binary,
+    TransportKind: MitsubishiTransportKind.Tcp,
+    Route: MitsubishiRoute.Default,
+    MonitoringTimer: 0x0010,
+    SerialNumberProvider: () => (ushort)Environment.TickCount);
+```
+
+### ASCII endpoint example
+
+```csharp
+var asciiOptions = new MitsubishiClientOptions(
+    Host: "192.168.0.40",
+    Port: 5000,
+    FrameType: MitsubishiFrameType.ThreeE,
+    DataCode: CommunicationDataCode.Ascii,
+    TransportKind: MitsubishiTransportKind.Tcp,
+    Route: MitsubishiRoute.Default,
+    MonitoringTimer: 0x0010);
+```
+
+### UDP endpoint example
+
+```csharp
+var udpOptions = new MitsubishiClientOptions(
+    Host: "192.168.0.50",
+    Port: 5000,
+    FrameType: MitsubishiFrameType.ThreeE,
+    DataCode: CommunicationDataCode.Binary,
+    TransportKind: MitsubishiTransportKind.Udp,
+    Route: MitsubishiRoute.Default,
+    MonitoringTimer: 0x0010);
+```
+
+### Serial endpoint example
+
+```csharp
+using System.IO.Ports;
+
+var serialEndpoint = new MitsubishiClientOptions(
+    Host: "COM3",
+    Port: 0,
+    FrameType: MitsubishiFrameType.OneC,
+    DataCode: CommunicationDataCode.Ascii,
+    TransportKind: MitsubishiTransportKind.Serial,
+    Timeout: TimeSpan.FromSeconds(2),
+    CpuType: CpuType.Fx3,
+    Serial: new MitsubishiSerialOptions(
+        PortName: "COM3",
+        BaudRate: 9600,
+        DataBits: 7,
+        Parity: Parity.Even,
+        StopBits: StopBits.One,
+        Handshake: Handshake.None,
+        MessageFormat: MitsubishiSerialMessageFormat.Format1,
+        StationNumber: 0x00,
+        PcNumber: 0xFF,
+        MessageWait: 0x0));
+```
+
+---
+
+## Feature-to-API quick map
+
+| Feature | API |
+|---|---|
+| Open transport | `OpenAsync()` / `Open()` |
+| Close transport | `CloseAsync()` / `Close()` |
+| Batch word read | `ReadWordsAsync(address, points)` |
+| Batch word write | `WriteWordsAsync(address, values)` |
+| Batch bit read | `ReadBitsAsync(address, points)` |
+| Batch bit write | `WriteBitsAsync(address, values)` |
+| Random word read | `RandomReadWordsAsync(addresses)` |
+| Random word write | `RandomWriteWordsAsync(values)` |
+| Register monitor devices | `RegisterMonitorAsync(addresses)` |
+| Execute monitor | `ExecuteMonitorAsync()` |
+| Block read | `ReadBlocksAsync(request)` |
+| Block write | `WriteBlocksAsync(request)` |
+| Read PLC type | `ReadTypeNameAsync()` |
+| Remote RUN | `RemoteRunAsync(force, clearMode)` |
+| Remote STOP | `RemoteStopAsync()` |
+| Remote PAUSE | `RemotePauseAsync()` |
+| Remote LATCH CLEAR | `RemoteLatchClearAsync()` |
+| Remote RESET | `RemoteResetAsync()` |
+| Unlock | `UnlockAsync(password)` |
+| Lock | `LockAsync(password)` |
+| Clear error | `ClearErrorAsync()` |
+| Loopback | `LoopbackAsync(data)` |
+| Memory read | `ReadMemoryAsync(command, address, length)` |
+| Memory write | `WriteMemoryAsync(command, address, values)` |
+| Raw command execution | `ExecuteRawAsync(request)` |
+| Observe words | `ObserveWords(...)` |
+| Observe bits | `ObserveBits(...)` |
+| Observe heartbeat | `ObserveWordsHeartbeat(...)` |
+| Observe staleness | `ObserveWordsStale(...)` |
+| Triggered latest read | `ObserveWordsLatest(...)` |
+| Observe tag group | `ObserveTagGroup(...)` |
+| Observe tag group heartbeat | `ObserveTagGroupHeartbeat(...)` |
+| Observe tag group staleness | `ObserveTagGroupStale(...)` |
+| Triggered latest tag-group read | `ObserveTagGroupLatest(...)` |
+| Operation logs | `OperationLogs` |
+| Connection states | `ConnectionStates` |
+| Connection stale detection | `ObserveConnectionHealth(...)` |
+| Symbolic word read | `ReadWordsByTagAsync(tagName, points)` |
+| Symbolic bit read | `ReadBitsByTagAsync(tagName, points)` |
+| Symbolic word write | `WriteWordsByTagAsync(tagName, values)` |
+| Symbolic bit write | `WriteBitsByTagAsync(tagName, values)` |
+| Symbolic random word read | `RandomReadWordsByTagAsync(tagNames)` |
+| Symbolic random word write | `RandomWriteWordsByTagAsync(values)` |
+| Symbolic Int16 read | `ReadInt16ByTagAsync(tagName)` |
+| Symbolic Int16 write | `WriteInt16ByTagAsync(tagName, value)` |
+| Symbolic UInt16 read | `ReadUInt16ByTagAsync(tagName)` |
+| Symbolic UInt16 write | `WriteUInt16ByTagAsync(tagName, value)` |
+| Symbolic Int32 read | `ReadInt32ByTagAsync(tagName)` |
+| Symbolic Int32 write | `WriteInt32ByTagAsync(tagName, value)` |
+| Symbolic DWord read | `ReadDWordByTagAsync(tagName)` |
+| Symbolic DWord write | `WriteDWordByTagAsync(tagName, value)` |
+| Symbolic float read | `ReadFloatByTagAsync(tagName)` |
+| Symbolic float write | `WriteFloatByTagAsync(tagName, value)` |
+| Symbolic scaled read | `ReadScaledDoubleByTagAsync(tagName)` |
+| Symbolic scaled write | `WriteScaledDoubleByTagAsync(tagName, value)` |
+| Symbolic string read | `ReadStringByTagAsync(tagName, wordLength)` / `ReadStringByTagAsync(tagName)` |
+| Symbolic string write | `WriteStringByTagAsync(tagName, value, wordLength)` / `WriteStringByTagAsync(tagName, value)` |
+| Tag group definition | `MitsubishiTagGroupDefinition(name, tagNames)` |
+| Tag group registration | `TagDatabase.AddGroup(group)` |
+| Tag database validation | `ValidateTagDatabase()` |
+| Tag database load + validate | `LoadAndValidateTagDatabase(path)` / `LoadAndValidateTagDatabase(path, policy)` |
+| Tag database diff preview | `PreviewTagDatabaseDiff(path)` / `PreviewTagDatabaseDiff(path, policy)` |
+| Tag database reload stream | `ObserveTagDatabaseReload(path, pollInterval)` / `ObserveTagDatabaseReload(path, pollInterval, emitInitial, policy)` |
+| Tag database diff stream | `ObserveTagDatabaseDiff(path, pollInterval)` / `ObserveTagDatabaseDiff(path, pollInterval, emitInitial, policy)` |
+| Tag group snapshot read | `ReadTagGroupSnapshotAsync(groupName)` |
+| Snapshot typed accessor | `snapshot.GetRequired<T>(tagName)` |
+| Tag group write validation | `ValidateTagGroupWrite(groupName, values)` |
+| Partial tag-group write | `WriteTagGroupValuesAsync(groupName, values)` |
+| Full tag-group snapshot write | `WriteTagGroupSnapshotAsync(snapshot)` |
+| Tag database assignment | `client.TagDatabase = ...` |
+| CSV tag import | `MitsubishiTagDatabase.FromCsv(csvContent)` |
+| Schema file load | `MitsubishiTagDatabase.Load(path)` |
+| Schema file save | `TagDatabase.Save(path)` |
+| JSON schema import | `MitsubishiTagDatabase.FromJson(json)` |
+| JSON schema export | `TagDatabase.ToJson()` |
+| YAML schema import | `MitsubishiTagDatabase.FromYaml(yaml)` |
+| YAML schema export | `TagDatabase.ToYaml()` |
+
+### Serial coverage note
+
+The quick map lists the full public API surface. Current serial support is narrower than Ethernet support. At this stage, the verified serial operation is **batch word read** via `ReadWordsAsync(address, points)` using `1C`, `3C`, or `4C` plus `MitsubishiTransportKind.Serial`.
+
+---
+
+## Troubleshooting notes
+
+### Tag name not found
+
+If tag-based reads fail, verify:
+- `client.TagDatabase` has been assigned
+- `Name` matches the CSV/configured value
+- the tag’s `Address` is a valid Mitsubishi address string
+
+### Wrong X / Y values
+
+If `X` or `Y` values do not match the PLC documentation:
+- switch `XyNotation` between `Octal` and `Hexadecimal`
+- confirm the expected addressing rule for the installed Ethernet module/path
+
+### ASCII vs binary mismatch
+
+If communication succeeds on one endpoint but not another:
+- verify whether the PLC/module is configured for `Binary` or `Ascii`
+- verify frame family (`OneE`, `ThreeE`, `FourE`, `OneC`, `ThreeC`, `FourC`)
+- verify TCP vs UDP vs serial configuration on the PLC/module side
+- for serial, also verify `MitsubishiSerialMessageFormat` (`Format1`, `Format4`, `Format5`) and serial-port settings such as baud rate, parity, stop bits, and handshake
+
+### Serial support limitations
+
+Current serial implementation is intentionally narrower than Ethernet support. If a serial operation fails, first confirm that the current serial implementation actually covers that scenario.
+
+Currently implemented and verified for serial:
+- reactive SerialPortRx-based transport
+- serial batch word reads through `ReadWordsAsync(address, points)`
+- `1C`, `3C`, and `4C` frame selection
+- serial ASCII format 1/4 and 4C binary format 5 decode paths
+
+Not yet implemented for serial:
+- serial writes
+- random operations
+- block operations
+- monitor registration/execution
+- remote control commands
+- memory / extend-unit commands
+- raw serial command execution
+
+### Remote operations do not execute
+
+Remote operations are target-dependent. Check:
+- CPU mode and permissions
+- Ethernet module settings
+- remote password/lock state
+- target family support and documented operational constraints
+
+---
+
+## Verification
+
+Validated with:
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" build src/MitsubishiRx.sln -v minimal
+"/mnt/c/Program Files/dotnet/dotnet.exe" test --project tests/MitsubishiRx.Tests/MitsubishiRx.Tests.csproj -v minimal
+```
+
+---
 
 ## License
-This project is licensed under the MIT License. See the LICENSE file for details.
 
-## Support
-If you encounter any issues or have questions, feel free to open an issue in the Issues section.
-
+MIT

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/MitsubishiRx.sln
+++ b/src/MitsubishiRx.sln
@@ -5,19 +5,57 @@ VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MitsubishiRx", "MitsubishiRx\MitsubishiRx.csproj", "{5B7BE84E-DF37-42D3-8811-0D6964003EB0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MitsubishiRx.Tests", "..\tests\MitsubishiRx.Tests\MitsubishiRx.Tests.csproj", "{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		PreRelease|Any CPU = PreRelease|Any CPU
+		PreRelease|x64 = PreRelease|x64
+		PreRelease|x86 = PreRelease|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Debug|x64.Build.0 = Debug|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Debug|x86.Build.0 = Debug|Any CPU
 		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.PreRelease|Any CPU.ActiveCfg = PreRelease|Any CPU
 		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.PreRelease|Any CPU.Build.0 = PreRelease|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.PreRelease|x64.ActiveCfg = PreRelease|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.PreRelease|x64.Build.0 = PreRelease|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.PreRelease|x86.ActiveCfg = PreRelease|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.PreRelease|x86.Build.0 = PreRelease|Any CPU
 		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Release|x64.ActiveCfg = Release|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Release|x64.Build.0 = Release|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Release|x86.ActiveCfg = Release|Any CPU
+		{5B7BE84E-DF37-42D3-8811-0D6964003EB0}.Release|x86.Build.0 = Release|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Debug|x64.Build.0 = Debug|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Debug|x86.Build.0 = Debug|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.PreRelease|Any CPU.ActiveCfg = PreRelease|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.PreRelease|Any CPU.Build.0 = PreRelease|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.PreRelease|x64.ActiveCfg = PreRelease|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.PreRelease|x64.Build.0 = PreRelease|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.PreRelease|x86.ActiveCfg = PreRelease|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.PreRelease|x86.Build.0 = PreRelease|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Release|x64.ActiveCfg = Release|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Release|x64.Build.0 = Release|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Release|x86.ActiveCfg = Release|Any CPU
+		{A52D9B7E-344F-428D-8E9C-38E40BE5F41A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MitsubishiRx/CpuType.cs
+++ b/src/MitsubishiRx/CpuType.cs
@@ -1,24 +1,50 @@
 ﻿// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace MitsubishiRx
+namespace MitsubishiRx;
+
+/// <summary>
+/// Defines the supported Mitsubishi PLC / Ethernet endpoint families.
+/// </summary>
+public enum CpuType
 {
     /// <summary>
-    /// CpuType.
+    /// No explicit family hint.
     /// </summary>
-    public enum CpuType
-    {
-        /// <summary>
-        /// The none.
-        /// </summary>
-        None,
-        /// <summary>
-        /// The a1e cpu.
-        /// </summary>
-        A1E,
-        /// <summary>
-        /// The qna3e cpu.
-        /// </summary>
-        Qna3E,
-    }
+    None,
+
+    /// <summary>
+    /// MELSEC-A / AnS family using A-compatible Ethernet modules.
+    /// </summary>
+    ASeries,
+
+    /// <summary>
+    /// MELSEC-QnA family.
+    /// </summary>
+    QnaSeries,
+
+    /// <summary>
+    /// MELSEC-Q family.
+    /// </summary>
+    QSeries,
+
+    /// <summary>
+    /// MELSEC-L family.
+    /// </summary>
+    LSeries,
+
+    /// <summary>
+    /// MELSEC-FX3 family.
+    /// </summary>
+    Fx3,
+
+    /// <summary>
+    /// MELSEC iQ-F / FX5 family.
+    /// </summary>
+    Fx5,
+
+    /// <summary>
+    /// MELSEC iQ-R family.
+    /// </summary>
+    IQR,
 }

--- a/src/MitsubishiRx/Enums.cs
+++ b/src/MitsubishiRx/Enums.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx;
+
+/// <summary>
+/// Defines the Mitsubishi MC protocol frame families supported by the client.
+/// </summary>
+public enum MitsubishiFrameType
+{
+    /// <summary>
+    /// A-compatible 1E Ethernet frame.
+    /// </summary>
+    OneE,
+
+    /// <summary>
+    /// QnA-compatible 3E Ethernet frame.
+    /// </summary>
+    ThreeE,
+
+    /// <summary>
+    /// QnA-compatible 4E Ethernet frame with serial correlation.
+    /// </summary>
+    FourE,
+
+    /// <summary>
+    /// A-compatible 1C serial frame.
+    /// </summary>
+    OneC,
+
+    /// <summary>
+    /// QnA-compatible 3C serial frame.
+    /// </summary>
+    ThreeC,
+
+    /// <summary>
+    /// QnA-compatible 4C serial frame.
+    /// </summary>
+    FourC,
+}
+
+/// <summary>
+/// Defines the data encoding used by MC protocol / SLMP packets.
+/// </summary>
+public enum CommunicationDataCode
+{
+    /// <summary>
+    /// Packed binary protocol representation.
+    /// </summary>
+    Binary,
+
+    /// <summary>
+    /// ASCII hexadecimal protocol representation.
+    /// </summary>
+    Ascii,
+}
+
+/// <summary>
+/// Defines the transport used to exchange Mitsubishi MC protocol frames.
+/// </summary>
+public enum MitsubishiTransportKind
+{
+    /// <summary>
+    /// TCP request/response transport.
+    /// </summary>
+    Tcp,
+
+    /// <summary>
+    /// UDP datagram transport.
+    /// </summary>
+    Udp,
+
+    /// <summary>
+    /// Serial transport using a reactive SerialPortRx implementation.
+    /// </summary>
+    Serial,
+}
+
+/// <summary>
+/// Defines how X and Y addresses should be parsed.
+/// </summary>
+public enum XyAddressNotation
+{
+    /// <summary>
+    /// Parse X/Y device numbers as octal values.
+    /// </summary>
+    Octal,
+
+    /// <summary>
+    /// Parse X/Y device numbers as hexadecimal values.
+    /// </summary>
+    Hexadecimal,
+}
+
+/// <summary>
+/// Defines high-level Mitsubishi connection states published by the client.
+/// </summary>
+public enum MitsubishiConnectionState
+{
+    /// <summary>
+    /// The transport is disconnected.
+    /// </summary>
+    Disconnected,
+
+    /// <summary>
+    /// The client is establishing a transport connection.
+    /// </summary>
+    Connecting,
+
+    /// <summary>
+    /// The transport is connected and ready.
+    /// </summary>
+    Connected,
+
+    /// <summary>
+    /// The client is recovering after a fault.
+    /// </summary>
+    Reconnecting,
+
+    /// <summary>
+    /// The client observed a terminal transport or protocol failure.
+    /// </summary>
+    Faulted,
+}

--- a/src/MitsubishiRx/MitsubishiCommands.cs
+++ b/src/MitsubishiRx/MitsubishiCommands.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx;
+
+/// <summary>
+/// Well-known MC protocol / SLMP command identifiers used by Mitsubishi Ethernet PLCs.
+/// </summary>
+public static class MitsubishiCommands
+{
+    /// <summary>
+    /// Batch device read.
+    /// </summary>
+    public const ushort DeviceRead = 0x0401;
+
+    /// <summary>
+    /// Batch device write.
+    /// </summary>
+    public const ushort DeviceWrite = 0x1401;
+
+    /// <summary>
+    /// Random device read.
+    /// </summary>
+    public const ushort RandomRead = 0x0403;
+
+    /// <summary>
+    /// Random device write.
+    /// </summary>
+    public const ushort RandomWrite = 0x1402;
+
+    /// <summary>
+    /// Block read.
+    /// </summary>
+    public const ushort BlockRead = 0x0406;
+
+    /// <summary>
+    /// Block write.
+    /// </summary>
+    public const ushort BlockWrite = 0x1406;
+
+    /// <summary>
+    /// Monitor registration.
+    /// </summary>
+    public const ushort EntryMonitorDevice = 0x0801;
+
+    /// <summary>
+    /// Monitor execution.
+    /// </summary>
+    public const ushort ExecuteMonitor = 0x0802;
+
+    /// <summary>
+    /// Buffer memory access for intelligent modules.
+    /// </summary>
+    public const ushort ExtendUnitRead = 0x0601;
+
+    /// <summary>
+    /// Buffer memory write for intelligent modules.
+    /// </summary>
+    public const ushort ExtendUnitWrite = 0x1601;
+
+    /// <summary>
+    /// Memory read.
+    /// </summary>
+    public const ushort MemoryRead = 0x0613;
+
+    /// <summary>
+    /// Memory write.
+    /// </summary>
+    public const ushort MemoryWrite = 0x1613;
+
+    /// <summary>
+    /// Read PLC type name.
+    /// </summary>
+    public const ushort ReadTypeName = 0x0101;
+
+    /// <summary>
+    /// Remote run.
+    /// </summary>
+    public const ushort RemoteRun = 0x1001;
+
+    /// <summary>
+    /// Remote stop.
+    /// </summary>
+    public const ushort RemoteStop = 0x1002;
+
+    /// <summary>
+    /// Remote pause.
+    /// </summary>
+    public const ushort RemotePause = 0x1003;
+
+    /// <summary>
+    /// Remote latch clear.
+    /// </summary>
+    public const ushort RemoteLatchClear = 0x1005;
+
+    /// <summary>
+    /// Remote reset.
+    /// </summary>
+    public const ushort RemoteReset = 0x1006;
+
+    /// <summary>
+    /// Unlock with remote password.
+    /// </summary>
+    public const ushort Unlock = 0x1630;
+
+    /// <summary>
+    /// Lock with remote password.
+    /// </summary>
+    public const ushort Lock = 0x1631;
+
+    /// <summary>
+    /// Loopback self test.
+    /// </summary>
+    public const ushort LoopbackTest = 0x0619;
+
+    /// <summary>
+    /// Clear error and LED indication.
+    /// </summary>
+    public const ushort ClearError = 0x1617;
+}

--- a/src/MitsubishiRx/MitsubishiDeviceAddress.cs
+++ b/src/MitsubishiRx/MitsubishiDeviceAddress.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.ObjectModel;
+
+namespace MitsubishiRx;
+
+/// <summary>
+/// Represents a parsed Mitsubishi device address.
+/// </summary>
+/// <param name="Symbol">Device symbol.</param>
+/// <param name="Number">Parsed device number.</param>
+/// <param name="Notation">Notation used during parsing.</param>
+/// <param name="Original">Original device text.</param>
+public sealed partial record MitsubishiDeviceAddress(string Symbol, int Number, XyAddressNotation Notation, string Original)
+{
+    private static readonly ReadOnlyDictionary<string, MitsubishiDeviceMetadata> s_metadata = new(
+        new Dictionary<string, MitsubishiDeviceMetadata>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X"] = new("X", 0x9C, 0x5820, DeviceValueKind.Bit, DeviceNumberFormat.XyVariable),
+            ["Y"] = new("Y", 0x9D, 0x5920, DeviceValueKind.Bit, DeviceNumberFormat.XyVariable),
+            ["M"] = new("M", 0x90, 0x4D20, DeviceValueKind.Bit, DeviceNumberFormat.Decimal),
+            ["L"] = new("L", 0x92, 0x4C20, DeviceValueKind.Bit, DeviceNumberFormat.Decimal),
+            ["B"] = new("B", 0xA0, 0x4220, DeviceValueKind.Bit, DeviceNumberFormat.Hexadecimal),
+            ["D"] = new("D", 0xA8, 0x4420, DeviceValueKind.Word, DeviceNumberFormat.Decimal),
+            ["W"] = new("W", 0xB4, 0x5720, DeviceValueKind.Word, DeviceNumberFormat.Hexadecimal),
+            ["R"] = new("R", 0xAF, 0x5220, DeviceValueKind.Word, DeviceNumberFormat.Decimal),
+            ["ZR"] = new("ZR", 0xB0, 0x5A52, DeviceValueKind.Word, DeviceNumberFormat.Hexadecimal),
+            ["TN"] = new("TN", 0xC2, 0x544E, DeviceValueKind.Word, DeviceNumberFormat.Decimal),
+            ["TS"] = new("TS", 0xC1, 0x5453, DeviceValueKind.Bit, DeviceNumberFormat.Decimal),
+            ["TC"] = new("TC", 0xC0, 0x5443, DeviceValueKind.Bit, DeviceNumberFormat.Decimal),
+            ["CN"] = new("CN", 0xC5, 0x434E, DeviceValueKind.Word, DeviceNumberFormat.Decimal),
+            ["CS"] = new("CS", 0xC4, 0x4353, DeviceValueKind.Bit, DeviceNumberFormat.Decimal),
+            ["CC"] = new("CC", 0xC3, 0x4343, DeviceValueKind.Bit, DeviceNumberFormat.Decimal),
+            ["SM"] = new("SM", 0x91, 0x534D, DeviceValueKind.Bit, DeviceNumberFormat.Decimal),
+            ["SD"] = new("SD", 0xA9, 0x5344, DeviceValueKind.Word, DeviceNumberFormat.Decimal),
+        });
+
+    /// <summary>
+    /// Gets the device metadata table used by the library.
+    /// </summary>
+    public static IReadOnlyDictionary<string, MitsubishiDeviceMetadata> Metadata => s_metadata;
+
+    /// <summary>
+    /// Parses a device string.
+    /// </summary>
+    /// <param name="value">Device text such as D100 or X10.</param>
+    /// <param name="xyNotation">How X and Y addresses should be interpreted.</param>
+    /// <returns>The parsed address.</returns>
+    public static MitsubishiDeviceAddress Parse(string value, XyAddressNotation xyNotation = XyAddressNotation.Octal)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        var trimmed = value.Trim().ToUpperInvariant();
+        var match = DeviceRegex().Match(trimmed);
+        if (!match.Success)
+        {
+            throw new FormatException($"Invalid Mitsubishi device address '{value}'.");
+        }
+
+        var symbol = match.Groups[1].Value;
+        var numberText = match.Groups[2].Value;
+        if (!s_metadata.TryGetValue(symbol, out var metadata))
+        {
+            throw new NotSupportedException($"Device '{symbol}' is not currently supported.");
+        }
+
+        var number = Convert.ToInt32(numberText, metadata.GetRadix(xyNotation));
+        return new MitsubishiDeviceAddress(symbol, number, xyNotation, trimmed);
+    }
+
+    /// <summary>
+    /// Gets the static metadata for the parsed symbol.
+    /// </summary>
+    public MitsubishiDeviceMetadata Descriptor => s_metadata[Symbol];
+
+    [System.Text.RegularExpressions.GeneratedRegex("^([A-Z]+)([0-9A-F]+)$", System.Text.RegularExpressions.RegexOptions.CultureInvariant)]
+    private static partial System.Text.RegularExpressions.Regex DeviceRegex();
+}
+
+/// <summary>
+/// Describes a Mitsubishi device family.
+/// </summary>
+/// <param name="Symbol">Canonical device symbol.</param>
+/// <param name="BinaryCode">Binary MC/SLMP device code.</param>
+/// <param name="AsciiCode">ASCII MC/SLMP device code encoded as hexadecimal bytes.</param>
+/// <param name="Kind">Whether the device is bit or word based.</param>
+/// <param name="NumberFormat">Address radix rules.</param>
+public sealed record MitsubishiDeviceMetadata(string Symbol, ushort BinaryCode, ushort AsciiCode, DeviceValueKind Kind, DeviceNumberFormat NumberFormat)
+{
+    /// <summary>
+    /// Resolves the numeric radix used for the device.
+    /// </summary>
+    /// <param name="xyNotation">Configured X/Y notation.</param>
+    /// <returns>The radix.</returns>
+    public int GetRadix(XyAddressNotation xyNotation) => NumberFormat switch
+    {
+        DeviceNumberFormat.Decimal => 10,
+        DeviceNumberFormat.Hexadecimal => 16,
+        DeviceNumberFormat.Octal => 8,
+        DeviceNumberFormat.XyVariable => xyNotation == XyAddressNotation.Octal ? 8 : 16,
+        _ => throw new ArgumentOutOfRangeException(nameof(NumberFormat)),
+    };
+}
+
+/// <summary>
+/// Defines whether a device stores bits or words.
+/// </summary>
+public enum DeviceValueKind
+{
+    /// <summary>
+    /// Bit addressable device.
+    /// </summary>
+    Bit,
+
+    /// <summary>
+    /// Word addressable device.
+    /// </summary>
+    Word,
+}
+
+/// <summary>
+/// Defines the supported address number formats for a device family.
+/// </summary>
+public enum DeviceNumberFormat
+{
+    /// <summary>
+    /// Decimal address values.
+    /// </summary>
+    Decimal,
+
+    /// <summary>
+    /// Hexadecimal address values.
+    /// </summary>
+    Hexadecimal,
+
+    /// <summary>
+    /// Octal address values.
+    /// </summary>
+    Octal,
+
+    /// <summary>
+    /// X/Y devices can be octal or hexadecimal depending on configuration.
+    /// </summary>
+    XyVariable,
+}

--- a/src/MitsubishiRx/MitsubishiModels.cs
+++ b/src/MitsubishiRx/MitsubishiModels.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.ObjectModel;
+
+namespace MitsubishiRx;
+
+/// <summary>
+/// Connection settings for the Mitsubishi reactive client.
+/// </summary>
+/// <param name="Host">Target host name, IP address, or serial port name.</param>
+/// <param name="Port">Target TCP/UDP port configured on the PLC or Ethernet module.</param>
+/// <param name="FrameType">Frame family used for communication.</param>
+/// <param name="DataCode">ASCII or binary protocol encoding.</param>
+/// <param name="TransportKind">TCP, UDP, or serial transport.</param>
+/// <param name="Route">SLMP routing metadata for 3E/4E frames.</param>
+/// <param name="MonitoringTimer">Monitoring timer in 250 ms units.</param>
+/// <param name="Timeout">Transport timeout.</param>
+/// <param name="CpuType">Optional family hint.</param>
+/// <param name="XyNotation">How X and Y device addresses are parsed.</param>
+/// <param name="LegacyPcNumber">PC number used for 1E frames.</param>
+/// <param name="SerialNumberProvider">4E serial number generator.</param>
+/// <param name="Serial">Optional reactive serial transport settings for 1C/3C/4C communication.</param>
+public sealed record MitsubishiClientOptions(
+    string Host,
+    int Port,
+    MitsubishiFrameType FrameType,
+    CommunicationDataCode DataCode,
+    MitsubishiTransportKind TransportKind,
+    MitsubishiRoute? Route = null,
+    ushort MonitoringTimer = 0x0010,
+    TimeSpan? Timeout = null,
+    CpuType CpuType = CpuType.None,
+    XyAddressNotation XyNotation = XyAddressNotation.Octal,
+    byte LegacyPcNumber = 0xFF,
+    Func<ushort>? SerialNumberProvider = null,
+    MitsubishiSerialOptions? Serial = null)
+{
+    /// <summary>
+    /// Gets the resolved timeout.
+    /// </summary>
+    public TimeSpan ResolvedTimeout => Timeout ?? TimeSpan.FromSeconds(4);
+
+    /// <summary>
+    /// Gets the resolved route.
+    /// </summary>
+    public MitsubishiRoute ResolvedRoute => Route ?? MitsubishiRoute.Default;
+
+    /// <summary>
+    /// Gets the configured serial options or throws when serial transport is selected without them.
+    /// </summary>
+    public MitsubishiSerialOptions ResolvedSerial => Serial ?? throw new InvalidOperationException("Serial transport requires Serial options.");
+
+    /// <summary>
+    /// Gets the next serial number for 4E packets.
+    /// </summary>
+    /// <returns>The next serial number.</returns>
+    public ushort GetNextSerialNumber() => SerialNumberProvider?.Invoke() ?? 0;
+}
+
+/// <summary>
+/// Represents a 3E / 4E access route.
+/// </summary>
+/// <param name="NetworkNumber">Destination network number.</param>
+/// <param name="StationNumber">Destination station number.</param>
+/// <param name="ModuleIoNumber">Destination module I/O number.</param>
+/// <param name="MultidropStationNumber">Destination multidrop station number.</param>
+/// <param name="ExtensionStationNumber">Optional extension station number for TSN / station extension frames.</param>
+public sealed record MitsubishiRoute(
+    byte NetworkNumber,
+    byte StationNumber,
+    ushort ModuleIoNumber,
+    byte MultidropStationNumber,
+    ushort? ExtensionStationNumber = null)
+{
+    /// <summary>
+    /// Gets the standard direct-connect route for the own station CPU.
+    /// </summary>
+    public static MitsubishiRoute Default { get; } = new(0x00, 0xFF, 0x03FF, 0x00);
+}
+
+/// <summary>
+/// Carries a low-level encoded MC protocol command request.
+/// </summary>
+/// <param name="Command">Command number.</param>
+/// <param name="Subcommand">Subcommand number.</param>
+/// <param name="Body">Encoded request body.</param>
+/// <param name="Description">Human readable description.</param>
+public sealed record MitsubishiRawCommandRequest(ushort Command, ushort Subcommand, IReadOnlyList<byte>? Body = null, string? Description = null)
+{
+    /// <summary>
+    /// Gets the request body as a read-only list.
+    /// </summary>
+    public IReadOnlyList<byte> ResolvedBody => Body ?? Array.Empty<byte>();
+}
+
+/// <summary>
+/// Represents an encoded transport exchange.
+/// </summary>
+/// <param name="Payload">Bytes to send.</param>
+/// <param name="ExpectedResponseLength">Expected response length for fixed-size frame types.</param>
+/// <param name="Description">Human readable description.</param>
+public sealed record MitsubishiTransportRequest(byte[] Payload, int? ExpectedResponseLength, string Description);
+
+/// <summary>
+/// Structured operation log entry emitted by the reactive client.
+/// </summary>
+/// <param name="TimestampUtc">Event time in UTC.</param>
+/// <param name="State">Current connection state.</param>
+/// <param name="Description">Operation description.</param>
+/// <param name="Success">Whether the step succeeded.</param>
+/// <param name="RequestPayload">Encoded request payload when available.</param>
+/// <param name="ResponsePayload">Encoded response payload when available.</param>
+/// <param name="Exception">Associated exception, if any.</param>
+public sealed record MitsubishiOperationLog(
+    DateTimeOffset TimestampUtc,
+    MitsubishiConnectionState State,
+    string Description,
+    bool Success,
+    ReadOnlyMemory<byte> RequestPayload,
+    ReadOnlyMemory<byte> ResponsePayload,
+    Exception? Exception = null);
+
+/// <summary>
+/// Rich PLC metadata returned by read-type operations.
+/// </summary>
+/// <param name="ModelName">Reported model name.</param>
+/// <param name="ModelCode">Reported model code.</param>
+public sealed record MitsubishiTypeName(string ModelName, ushort ModelCode);
+
+/// <summary>
+/// Represents a single device write value.
+/// </summary>
+/// <param name="Address">Target device.</param>
+/// <param name="Value">Value to write.</param>
+public sealed record MitsubishiDeviceValue(MitsubishiDeviceAddress Address, ushort Value);
+
+/// <summary>
+/// Represents a word device block for multiple block operations.
+/// </summary>
+/// <param name="Address">Start address.</param>
+/// <param name="Values">Words in the block.</param>
+public sealed record MitsubishiWordBlock(MitsubishiDeviceAddress Address, ReadOnlyMemory<ushort> Values);
+
+/// <summary>
+/// Represents a bit device block for multiple block operations.
+/// </summary>
+/// <param name="Address">Start address.</param>
+/// <param name="Values">Bit values in the block.</param>
+public sealed record MitsubishiBitBlock(MitsubishiDeviceAddress Address, ReadOnlyMemory<bool> Values);
+
+/// <summary>
+/// Multiple block read/write request payload.
+/// </summary>
+/// <param name="WordBlocks">Word blocks.</param>
+/// <param name="BitBlocks">Bit blocks.</param>
+public sealed record MitsubishiBlockRequest(IReadOnlyList<MitsubishiWordBlock>? WordBlocks = null, IReadOnlyList<MitsubishiBitBlock>? BitBlocks = null)
+{
+    /// <summary>
+    /// Gets the resolved word blocks.
+    /// </summary>
+    public IReadOnlyList<MitsubishiWordBlock> ResolvedWordBlocks => WordBlocks ?? Array.Empty<MitsubishiWordBlock>();
+
+    /// <summary>
+    /// Gets the resolved bit blocks.
+    /// </summary>
+    public IReadOnlyList<MitsubishiBitBlock> ResolvedBitBlocks => BitBlocks ?? Array.Empty<MitsubishiBitBlock>();
+}

--- a/src/MitsubishiRx/MitsubishiProtocolEncoding.cs
+++ b/src/MitsubishiRx/MitsubishiProtocolEncoding.cs
@@ -1,0 +1,768 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Text;
+
+namespace MitsubishiRx;
+
+internal static class MitsubishiProtocolEncoding
+{
+    public static byte[] Encode(MitsubishiClientOptions options, MitsubishiRawCommandRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(request);
+
+        return options.FrameType switch
+        {
+            MitsubishiFrameType.OneE => Encode1E(options, request),
+            MitsubishiFrameType.ThreeE => Encode3E(options, request),
+            MitsubishiFrameType.FourE => Encode4E(options, request),
+            _ => throw new ArgumentOutOfRangeException(nameof(options.FrameType)),
+        };
+    }
+
+    public static Responce<byte[]> Decode(MitsubishiClientOptions options, MitsubishiTransportRequest request, byte[] response)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(response);
+
+        return options.DataCode switch
+        {
+            CommunicationDataCode.Ascii => options.FrameType == MitsubishiFrameType.OneE ? Decode1EAscii(response) : Decode3EOr4EAscii(response),
+            _ => options.FrameType switch
+            {
+                MitsubishiFrameType.OneE => Decode1E(response),
+                MitsubishiFrameType.ThreeE or MitsubishiFrameType.FourE => Decode3EOr4E(response),
+                _ => throw new ArgumentOutOfRangeException(nameof(options.FrameType)),
+            },
+        };
+    }
+
+    public static int? GetFixedResponseLength(MitsubishiFrameType frameType, CommunicationDataCode dataCode, ushort command, ushort subcommand, int requestBodyLength, int? explicitLength = null)
+    {
+        if (explicitLength.HasValue)
+        {
+            return explicitLength;
+        }
+
+        return frameType switch
+        {
+            MitsubishiFrameType.OneE => GetFixedResponseLength1E(command, requestBodyLength, dataCode),
+            MitsubishiFrameType.ThreeE or MitsubishiFrameType.FourE => null,
+            _ => null,
+        };
+    }
+
+    public static byte[] EncodeDeviceBatchRead(MitsubishiClientOptions options, MitsubishiDeviceAddress address, int points, bool bitUnits)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(points);
+        var subcommand = options.FrameType == MitsubishiFrameType.OneE
+            ? (ushort)(bitUnits ? 0x0000 : 0x0001)
+            : (ushort)(bitUnits ? 0x0001 : 0x0000);
+        var body = options.FrameType == MitsubishiFrameType.OneE
+            ? Encode1EDeviceBody(address, points, options)
+            : Encode3EDeviceBody(address, points, options);
+
+        return Encode(options, new MitsubishiRawCommandRequest(MitsubishiCommands.DeviceRead, subcommand, body, $"Read {address.Original}"));
+    }
+
+    public static byte[] EncodeDeviceBatchWrite(MitsubishiClientOptions options, MitsubishiDeviceAddress address, ReadOnlySpan<ushort> values, bool bitUnits)
+    {
+        if (values.IsEmpty)
+        {
+            throw new ArgumentException("At least one value must be supplied.", nameof(values));
+        }
+
+        var subcommand = options.FrameType == MitsubishiFrameType.OneE
+            ? (ushort)(bitUnits ? 0x0002 : 0x0003)
+            : (ushort)(bitUnits ? 0x0001 : 0x0000);
+        var body = options.FrameType == MitsubishiFrameType.OneE
+            ? Encode1EDeviceWriteBody(address, values, options, bitUnits)
+            : Encode3EDeviceWriteBody(address, values, options, bitUnits);
+
+        return Encode(options, new MitsubishiRawCommandRequest(MitsubishiCommands.DeviceWrite, subcommand, body, $"Write {address.Original}"));
+    }
+
+    public static byte[] EncodeRandomRead(MitsubishiClientOptions options, IReadOnlyList<MitsubishiDeviceAddress> wordDevices)
+    {
+        ArgumentNullException.ThrowIfNull(wordDevices);
+        if (wordDevices.Count == 0)
+        {
+            throw new ArgumentException("At least one device must be supplied.", nameof(wordDevices));
+        }
+
+        var body = options.FrameType == MitsubishiFrameType.OneE
+            ? throw new NotSupportedException("1E random read is not implemented in this release.")
+            : Encode3ERandomReadBody(wordDevices, options);
+
+        return Encode(options, new MitsubishiRawCommandRequest(MitsubishiCommands.RandomRead, 0x0000, body, "Random read"));
+    }
+
+    public static byte[] EncodeRandomWrite(MitsubishiClientOptions options, IReadOnlyList<MitsubishiDeviceValue> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        if (values.Count == 0)
+        {
+            throw new ArgumentException("At least one device value must be supplied.", nameof(values));
+        }
+
+        var body = options.FrameType == MitsubishiFrameType.OneE
+            ? throw new NotSupportedException("1E random write is not implemented in this release.")
+            : Encode3ERandomWriteBody(values, options);
+
+        return Encode(options, new MitsubishiRawCommandRequest(MitsubishiCommands.RandomWrite, 0x0000, body, "Random write"));
+    }
+
+    public static byte[] EncodeMonitorRegistration(MitsubishiClientOptions options, IReadOnlyList<MitsubishiDeviceAddress> wordDevices)
+    {
+        ArgumentNullException.ThrowIfNull(wordDevices);
+        if (wordDevices.Count == 0)
+        {
+            throw new ArgumentException("At least one device must be supplied.", nameof(wordDevices));
+        }
+
+        var body = options.FrameType == MitsubishiFrameType.OneE
+            ? throw new NotSupportedException("1E monitor registration is not implemented in this release.")
+            : Encode3ERandomReadBody(wordDevices, options);
+
+        return Encode(options, new MitsubishiRawCommandRequest(MitsubishiCommands.EntryMonitorDevice, 0x0000, body, "Entry monitor device"));
+    }
+
+    public static byte[] EncodeExecuteMonitor(MitsubishiClientOptions options)
+        => Encode(options, new MitsubishiRawCommandRequest(MitsubishiCommands.ExecuteMonitor, 0x0000, Array.Empty<byte>(), "Execute monitor"));
+
+    public static byte[] EncodeBlockRead(MitsubishiClientOptions options, MitsubishiBlockRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (options.FrameType == MitsubishiFrameType.OneE)
+        {
+            throw new NotSupportedException("1E block read is not implemented in this release.");
+        }
+
+        var body = Encode3EBlocks(request, options, includeValues: false);
+        return Encode(options, new MitsubishiRawCommandRequest(MitsubishiCommands.BlockRead, 0x0000, body, "Block read"));
+    }
+
+    public static byte[] EncodeBlockWrite(MitsubishiClientOptions options, MitsubishiBlockRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (options.FrameType == MitsubishiFrameType.OneE)
+        {
+            throw new NotSupportedException("1E block write is not implemented in this release.");
+        }
+
+        var body = Encode3EBlocks(request, options, includeValues: true);
+        return Encode(options, new MitsubishiRawCommandRequest(MitsubishiCommands.BlockWrite, 0x0000, body, "Block write"));
+    }
+
+    public static byte[] EncodeReadTypeName(MitsubishiClientOptions options)
+        => Encode(options, new MitsubishiRawCommandRequest(MitsubishiCommands.ReadTypeName, 0x0000, Array.Empty<byte>(), "Read type name"));
+
+    public static byte[] EncodeRemoteOperation(MitsubishiClientOptions options, ushort command, bool force = true, bool clearMode = false)
+    {
+        byte[] body = command switch
+        {
+            MitsubishiCommands.RemoteRun => options.DataCode == CommunicationDataCode.Binary
+                ? [Convert.ToByte(force ? 0x01 : 0x00), Convert.ToByte(clearMode ? 0x01 : 0x00)]
+                : Encoding.ASCII.GetBytes($"{(force ? "0001" : "0000")}{(clearMode ? "0001" : "0000")}"),
+            MitsubishiCommands.RemoteStop or MitsubishiCommands.RemotePause or MitsubishiCommands.RemoteLatchClear or MitsubishiCommands.RemoteReset => Array.Empty<byte>(),
+            _ => throw new ArgumentOutOfRangeException(nameof(command)),
+        };
+
+        return Encode(options, new MitsubishiRawCommandRequest(command, 0x0000, body, $"Remote op {command:X4}"));
+    }
+
+    public static byte[] EncodeLoopback(MitsubishiClientOptions options, ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty)
+        {
+            throw new ArgumentException("Loopback payload must not be empty.", nameof(data));
+        }
+
+        byte[] body;
+        if (options.FrameType == MitsubishiFrameType.OneE)
+        {
+            body = options.DataCode == CommunicationDataCode.Binary
+                ? BuildLoopback1EBinary(data)
+                : BuildLoopback1EAscii(data);
+        }
+        else
+        {
+            body = options.DataCode == CommunicationDataCode.Binary
+                ? BuildLoopback3EBinary(data)
+                : BuildLoopback3EAscii(data);
+        }
+
+        return Encode(options, new MitsubishiRawCommandRequest(MitsubishiCommands.LoopbackTest, 0x0000, body, "Loopback"));
+    }
+
+    public static byte[] EncodeRemotePassword(MitsubishiClientOptions options, ushort command, string password)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+        var body = options.DataCode == CommunicationDataCode.Binary
+            ? BuildBinaryPasswordPayload(password)
+            : BuildAsciiPasswordPayload(password);
+        return Encode(options, new MitsubishiRawCommandRequest(command, 0x0000, body, command == MitsubishiCommands.Unlock ? "Unlock" : "Lock"));
+    }
+
+    public static byte[] EncodeMemoryAccess(MitsubishiClientOptions options, ushort command, ushort address, int length, ReadOnlySpan<ushort> values)
+    {
+        if (options.FrameType == MitsubishiFrameType.OneE)
+        {
+            throw new NotSupportedException("1E memory / extend unit access is not implemented in this release.");
+        }
+
+        var list = new List<byte>();
+        AppendUInt16(list, address, options.DataCode);
+        AppendUInt16(list, checked((ushort)length), options.DataCode);
+        if (command is MitsubishiCommands.MemoryWrite or MitsubishiCommands.ExtendUnitWrite)
+        {
+            foreach (var value in values)
+            {
+                AppendUInt16(list, value, options.DataCode);
+            }
+        }
+
+        return Encode(options, new MitsubishiRawCommandRequest(command, 0x0000, list, $"Memory op {command:X4}"));
+    }
+
+    private static byte[] Encode1E(MitsubishiClientOptions options, MitsubishiRawCommandRequest request)
+    {
+        var body = request.ResolvedBody;
+        var buffer = new List<byte>();
+        AppendByte(buffer, Get1ECommand(request.Command, request.Subcommand), options.DataCode);
+        AppendByte(buffer, options.LegacyPcNumber, options.DataCode);
+        AppendUInt16(buffer, options.MonitoringTimer, options.DataCode);
+        buffer.AddRange(body);
+        return buffer.ToArray();
+    }
+
+    private static byte[] Encode3E(MitsubishiClientOptions options, MitsubishiRawCommandRequest request)
+    {
+        var body = request.ResolvedBody;
+        var buffer = new List<byte>();
+        Append3EOr4ESubheader(buffer, options.DataCode, fourE: false, options.GetNextSerialNumber());
+        AppendRoute(buffer, options.ResolvedRoute, options.DataCode);
+        AppendUInt16(buffer, checked((ushort)(2 + 2 + 2 + body.Count)), options.DataCode);
+        AppendUInt16(buffer, options.MonitoringTimer, options.DataCode);
+        AppendUInt16(buffer, request.Command, options.DataCode);
+        AppendUInt16(buffer, request.Subcommand, options.DataCode);
+        buffer.AddRange(body);
+        return buffer.ToArray();
+    }
+
+    private static byte[] Encode4E(MitsubishiClientOptions options, MitsubishiRawCommandRequest request)
+    {
+        var body = request.ResolvedBody;
+        var buffer = new List<byte>();
+        Append3EOr4ESubheader(buffer, options.DataCode, fourE: true, options.GetNextSerialNumber());
+        AppendRoute(buffer, options.ResolvedRoute, options.DataCode);
+        AppendUInt16(buffer, checked((ushort)(2 + 2 + 2 + body.Count)), options.DataCode);
+        AppendUInt16(buffer, options.MonitoringTimer, options.DataCode);
+        AppendUInt16(buffer, request.Command, options.DataCode);
+        AppendUInt16(buffer, request.Subcommand, options.DataCode);
+        buffer.AddRange(body);
+        return buffer.ToArray();
+    }
+
+    private static Responce<byte[]> Decode1E(byte[] response)
+    {
+        var result = new Responce<byte[]> { Response = Convert.ToHexString(response) };
+        if (response.Length < 2)
+        {
+            return result.Fail("1E response too short.");
+        }
+
+        var endCode = response[1];
+        if (endCode == 0x5B)
+        {
+            var errorCode = response.Length >= 4 ? BinaryPrimitives.ReadUInt16LittleEndian(response.AsSpan(2, 2)) : (ushort)0;
+            return result.Fail($"PLC returned 1E error 0x{errorCode:X4}.", errorCode);
+        }
+
+        result.Value = response.Length > 2 ? response[2..] : Array.Empty<byte>();
+        return result.EndTime();
+    }
+
+    private static Responce<byte[]> Decode3EOr4E(byte[] response)
+    {
+        var result = new Responce<byte[]> { Response = Convert.ToHexString(response) };
+        if (response.Length < 11)
+        {
+            return result.Fail("3E/4E response too short.");
+        }
+
+        var isFourE = response[0] == 0xD4;
+        var offset = isFourE ? 6 : 2;
+        if (response.Length < offset + 9)
+        {
+            return result.Fail("3E/4E response header incomplete.");
+        }
+
+        var responseDataLength = BinaryPrimitives.ReadUInt16LittleEndian(response.AsSpan(offset + 5, 2));
+        var endCode = BinaryPrimitives.ReadUInt16LittleEndian(response.AsSpan(offset + 7, 2));
+        var payloadLength = Math.Max(0, responseDataLength - 2);
+        var payloadStart = offset + 9;
+        if (response.Length < payloadStart + payloadLength)
+        {
+            return result.Fail("3E/4E response payload truncated.");
+        }
+
+        if (endCode != 0)
+        {
+            result.ErrCode = endCode;
+            return result.Fail($"PLC returned error 0x{endCode:X4}.", endCode);
+        }
+
+        result.Value = payloadLength == 0 ? Array.Empty<byte>() : response[payloadStart..(payloadStart + payloadLength)];
+        return result.EndTime();
+    }
+
+    private static Responce<byte[]> Decode1EAscii(byte[] response)
+    {
+        var text = Encoding.ASCII.GetString(response);
+        var result = new Responce<byte[]> { Response = text };
+        if (text.Length < 4)
+        {
+            return result.Fail("1E ASCII response too short.");
+        }
+
+        var endCode = text.Substring(2, 2);
+        if (string.Equals(endCode, "5B", StringComparison.OrdinalIgnoreCase))
+        {
+            var errorCode = text.Length >= 8 ? Convert.ToInt32(text.Substring(4, 4), 16) : 0;
+            return result.Fail($"PLC returned 1E ASCII error 0x{errorCode:X4}.", errorCode);
+        }
+
+        result.Value = text.Length > 4 ? Encoding.ASCII.GetBytes(text[4..]) : Array.Empty<byte>();
+        return result.EndTime();
+    }
+
+    private static Responce<byte[]> Decode3EOr4EAscii(byte[] response)
+    {
+        var text = Encoding.ASCII.GetString(response);
+        var result = new Responce<byte[]> { Response = text };
+        var isFourE = text.StartsWith("D4", StringComparison.OrdinalIgnoreCase);
+        var expectedPrefixLength = isFourE ? 30 : 22;
+        if (text.Length < expectedPrefixLength)
+        {
+            return result.Fail("3E/4E ASCII response too short.");
+        }
+
+        var responseDataLength = Convert.ToInt32(text.Substring(isFourE ? 22 : 14, 4), 16);
+        var endCode = Convert.ToInt32(text.Substring(isFourE ? 26 : 18, 4), 16);
+        var payloadLength = Math.Max(0, responseDataLength - 2) * 2;
+        var payloadStart = isFourE ? 30 : 22;
+        var remaining = text.Length - payloadStart;
+        if (remaining == payloadLength - 4)
+        {
+            payloadStart -= 4;
+        }
+        else if (remaining == payloadLength + 4)
+        {
+            payloadStart += 4;
+        }
+
+        if (text.Length < payloadStart + payloadLength)
+        {
+            return result.Fail("3E/4E ASCII response payload truncated.");
+        }
+
+        if (endCode != 0)
+        {
+            result.ErrCode = endCode;
+            return result.Fail($"PLC returned ASCII error 0x{endCode:X4}.", endCode);
+        }
+
+        result.Value = payloadLength == 0 ? Array.Empty<byte>() : Encoding.ASCII.GetBytes(text.Substring(payloadStart, payloadLength));
+        return result.EndTime();
+    }
+
+    private static int? GetFixedResponseLength1E(ushort command, int requestBodyLength, CommunicationDataCode dataCode)
+        => command switch
+        {
+            MitsubishiCommands.DeviceRead when requestBodyLength >= 0 => dataCode == CommunicationDataCode.Ascii
+                ? 4 + (Math.Max(1, requestBodyLength / 10) * 4)
+                : 2 + Math.Max(1, requestBodyLength / 6),
+            MitsubishiCommands.LoopbackTest => dataCode == CommunicationDataCode.Ascii
+                ? 4 + requestBodyLength
+                : 4 + requestBodyLength,
+            _ => null,
+        };
+
+    private static byte[] Encode1EDeviceBody(MitsubishiDeviceAddress address, int points, MitsubishiClientOptions options)
+    {
+        var metadata = address.Descriptor;
+        if (options.DataCode == CommunicationDataCode.Binary)
+        {
+            var buffer = new List<byte>(8);
+            AppendLegacyHeadDevice(buffer, address, options.XyNotation);
+            AppendLegacyDeviceCode(buffer, metadata);
+            AppendByte(buffer, ConvertPointCountToLegacyByte(points), options.DataCode);
+            AppendByte(buffer, 0x00, options.DataCode);
+            return buffer.ToArray();
+        }
+
+        var text = FormatAsciiLegacyAddress(address, options.XyNotation) + FormatAsciiByte(ConvertPointCountToLegacyByte(points)) + "00";
+        return Encoding.ASCII.GetBytes(text);
+    }
+
+    private static byte[] Encode1EDeviceWriteBody(MitsubishiDeviceAddress address, ReadOnlySpan<ushort> values, MitsubishiClientOptions options, bool bitUnits)
+    {
+        var baseBody = Encode1EDeviceBody(address, values.Length, options).ToList();
+        if (options.DataCode == CommunicationDataCode.Binary)
+        {
+            if (bitUnits)
+            {
+                foreach (var value in values)
+                {
+                    baseBody.Add(Convert.ToByte(value != 0 ? 0x01 : 0x00));
+                }
+            }
+            else
+            {
+                foreach (var value in values)
+                {
+                    AppendUInt16(baseBody, value, options.DataCode);
+                }
+            }
+
+            return baseBody.ToArray();
+        }
+
+        var builder = new StringBuilder(Encoding.ASCII.GetString(baseBody.ToArray()));
+        if (bitUnits)
+        {
+            foreach (var value in values)
+            {
+                builder.Append(value == 0 ? '0' : '1');
+            }
+        }
+        else
+        {
+            foreach (var value in values)
+            {
+                builder.Append(FormatAsciiUInt16(value));
+            }
+        }
+
+        return Encoding.ASCII.GetBytes(builder.ToString());
+    }
+
+    private static byte[] Encode3EDeviceBody(MitsubishiDeviceAddress address, int points, MitsubishiClientOptions options)
+    {
+        var metadata = address.Descriptor;
+        var buffer = new List<byte>();
+        AppendDeviceAddress(buffer, address, options, legacy: false);
+        AppendUInt16(buffer, checked((ushort)points), options.DataCode);
+        return buffer.ToArray();
+    }
+
+    private static byte[] Encode3EDeviceWriteBody(MitsubishiDeviceAddress address, ReadOnlySpan<ushort> values, MitsubishiClientOptions options, bool bitUnits)
+    {
+        var buffer = new List<byte>();
+        buffer.AddRange(Encode3EDeviceBody(address, values.Length, options));
+        if (options.DataCode == CommunicationDataCode.Binary)
+        {
+            if (bitUnits)
+            {
+                foreach (var value in values)
+                {
+                    buffer.Add(Convert.ToByte(value == 0 ? 0x00 : 0x10));
+                }
+            }
+            else
+            {
+                foreach (var value in values)
+                {
+                    AppendUInt16(buffer, value, options.DataCode);
+                }
+            }
+        }
+        else
+        {
+            if (bitUnits)
+            {
+                foreach (var value in values)
+                {
+                    buffer.Add((byte)(value == 0 ? '0' : '1'));
+                }
+            }
+            else
+            {
+                foreach (var value in values)
+                {
+                    foreach (var b in Encoding.ASCII.GetBytes(FormatAsciiUInt16(value)))
+                    {
+                        buffer.Add(b);
+                    }
+                }
+            }
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static byte[] Encode3ERandomReadBody(IReadOnlyList<MitsubishiDeviceAddress> devices, MitsubishiClientOptions options)
+    {
+        var buffer = new List<byte>();
+        AppendByte(buffer, checked((byte)devices.Count), options.DataCode);
+        AppendByte(buffer, 0x00, options.DataCode);
+        foreach (var device in devices)
+        {
+            AppendDeviceAddress(buffer, device, options, legacy: false);
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static byte[] Encode3ERandomWriteBody(IReadOnlyList<MitsubishiDeviceValue> values, MitsubishiClientOptions options)
+    {
+        var buffer = new List<byte>();
+        AppendUInt16(buffer, checked((ushort)values.Count), options.DataCode);
+        AppendUInt16(buffer, 0x0000, options.DataCode);
+        foreach (var value in values)
+        {
+            AppendDeviceAddress(buffer, value.Address, options, legacy: false);
+            AppendUInt16(buffer, value.Value, options.DataCode);
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static byte[] Encode3EBlocks(MitsubishiBlockRequest request, MitsubishiClientOptions options, bool includeValues)
+    {
+        var buffer = new List<byte>();
+        AppendUInt16(buffer, checked((ushort)request.ResolvedWordBlocks.Count), options.DataCode);
+        AppendUInt16(buffer, checked((ushort)request.ResolvedBitBlocks.Count), options.DataCode);
+        foreach (var block in request.ResolvedWordBlocks)
+        {
+            AppendDeviceAddress(buffer, block.Address, options, legacy: false);
+            AppendUInt16(buffer, checked((ushort)block.Values.Length), options.DataCode);
+            if (includeValues)
+            {
+                foreach (var value in block.Values.Span)
+                {
+                    AppendUInt16(buffer, value, options.DataCode);
+                }
+            }
+        }
+
+        foreach (var block in request.ResolvedBitBlocks)
+        {
+            AppendDeviceAddress(buffer, block.Address, options, legacy: false);
+            AppendUInt16(buffer, checked((ushort)block.Values.Length), options.DataCode);
+            if (includeValues)
+            {
+                foreach (var value in block.Values.Span)
+                {
+                    AppendByte(buffer, value ? (byte)0x10 : (byte)0x00, options.DataCode);
+                }
+            }
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static byte[] BuildLoopback1EBinary(ReadOnlySpan<byte> data)
+    {
+        var buffer = new List<byte> { (byte)data.Length, 0x00 };
+        buffer.AddRange(data.ToArray());
+        return buffer.ToArray();
+    }
+
+    private static byte[] BuildLoopback1EAscii(ReadOnlySpan<byte> data)
+        => Encoding.ASCII.GetBytes(FormatAsciiByte((byte)data.Length) + Encoding.ASCII.GetString(data));
+
+    private static byte[] BuildLoopback3EBinary(ReadOnlySpan<byte> data)
+    {
+        var buffer = new List<byte>();
+        AppendUInt16(buffer, checked((ushort)data.Length), CommunicationDataCode.Binary);
+        buffer.AddRange(data.ToArray());
+        return buffer.ToArray();
+    }
+
+    private static byte[] BuildLoopback3EAscii(ReadOnlySpan<byte> data)
+        => Encoding.ASCII.GetBytes(FormatAsciiUInt16((ushort)data.Length) + Encoding.ASCII.GetString(data));
+
+    private static byte[] BuildBinaryPasswordPayload(string password)
+    {
+        var bytes = Encoding.ASCII.GetBytes(password);
+        var buffer = new List<byte>();
+        AppendUInt16(buffer, checked((ushort)bytes.Length), CommunicationDataCode.Binary);
+        buffer.AddRange(bytes);
+        return buffer.ToArray();
+    }
+
+    private static byte[] BuildAsciiPasswordPayload(string password)
+        => Encoding.ASCII.GetBytes(FormatAsciiUInt16((ushort)password.Length) + password.ToUpperInvariant());
+
+    private static void Append3EOr4ESubheader(List<byte> buffer, CommunicationDataCode dataCode, bool fourE, ushort serialNumber)
+    {
+        if (dataCode == CommunicationDataCode.Binary)
+        {
+            if (fourE)
+            {
+                buffer.Add(0x54);
+                buffer.Add(0x00);
+                AppendUInt16(buffer, serialNumber, dataCode);
+                buffer.Add(0x00);
+                buffer.Add(0x00);
+            }
+            else
+            {
+                buffer.Add(0x50);
+                buffer.Add(0x00);
+            }
+
+            return;
+        }
+
+        if (fourE)
+        {
+            foreach (var b in Encoding.ASCII.GetBytes($"5400{serialNumber:X4}0000"))
+            {
+                buffer.Add(b);
+            }
+        }
+        else
+        {
+            foreach (var b in Encoding.ASCII.GetBytes("5000"))
+            {
+                buffer.Add(b);
+            }
+        }
+    }
+
+    private static void AppendRoute(List<byte> buffer, MitsubishiRoute route, CommunicationDataCode dataCode)
+    {
+        AppendByte(buffer, route.NetworkNumber, dataCode);
+        AppendByte(buffer, route.StationNumber, dataCode);
+        AppendUInt16(buffer, route.ModuleIoNumber, dataCode);
+        AppendByte(buffer, route.MultidropStationNumber, dataCode);
+    }
+
+    private static void AppendDeviceAddress(List<byte> buffer, MitsubishiDeviceAddress address, MitsubishiClientOptions options, bool legacy)
+    {
+        var metadata = address.Descriptor;
+        if (options.DataCode == CommunicationDataCode.Binary)
+        {
+            if (legacy)
+            {
+                AppendLegacyHeadDevice(buffer, address, options.XyNotation);
+                AppendLegacyDeviceCode(buffer, metadata);
+            }
+            else
+            {
+                var raw = BitConverter.GetBytes(address.Number);
+                buffer.Add(raw[0]);
+                buffer.Add(raw[1]);
+                buffer.Add(raw[2]);
+                buffer.Add((byte)metadata.BinaryCode);
+            }
+
+            return;
+        }
+
+        if (legacy)
+        {
+            foreach (var b in Encoding.ASCII.GetBytes(FormatAsciiLegacyAddress(address, options.XyNotation)))
+            {
+                buffer.Add(b);
+            }
+
+            return;
+        }
+
+        foreach (var b in Encoding.ASCII.GetBytes(FormatAsciiModernAddress(address, metadata, options.XyNotation)))
+        {
+            buffer.Add(b);
+        }
+    }
+
+    private static void AppendLegacyHeadDevice(List<byte> buffer, MitsubishiDeviceAddress address, XyAddressNotation notation)
+    {
+        var bytes = BitConverter.GetBytes(address.Number);
+        buffer.Add(bytes[0]);
+        buffer.Add(bytes[1]);
+        buffer.Add(bytes[2]);
+        buffer.Add(0x00);
+    }
+
+    private static void AppendLegacyDeviceCode(List<byte> buffer, MitsubishiDeviceMetadata metadata)
+    {
+        var code = BitConverter.GetBytes(metadata.AsciiCode);
+        buffer.Add(code[0]);
+        buffer.Add(code[1]);
+    }
+
+    private static string FormatAsciiLegacyAddress(MitsubishiDeviceAddress address, XyAddressNotation notation)
+        => address.Number.ToString("X8", CultureInfo.InvariantCulture) + address.Descriptor.Symbol.PadRight(2, '*');
+
+    private static string FormatAsciiModernAddress(MitsubishiDeviceAddress address, MitsubishiDeviceMetadata metadata, XyAddressNotation notation)
+        => address.Number.ToString("X6", CultureInfo.InvariantCulture) + metadata.Symbol.PadRight(2, '*');
+
+    private static byte Get1ECommand(ushort command, ushort subcommand)
+        => command switch
+        {
+            MitsubishiCommands.DeviceRead when subcommand == 0x0000 => 0x00,
+            MitsubishiCommands.DeviceRead when subcommand == 0x0001 => 0x01,
+            MitsubishiCommands.DeviceWrite when subcommand == 0x0002 => 0x02,
+            MitsubishiCommands.DeviceWrite when subcommand == 0x0003 => 0x03,
+            MitsubishiCommands.RandomWrite when subcommand == 0x0001 => 0x04,
+            MitsubishiCommands.RandomWrite when subcommand == 0x0000 => 0x05,
+            MitsubishiCommands.EntryMonitorDevice => 0x06,
+            MitsubishiCommands.ExecuteMonitor => 0x08,
+            MitsubishiCommands.RemoteRun => 0x13,
+            MitsubishiCommands.RemoteStop => 0x14,
+            MitsubishiCommands.ReadTypeName => 0x15,
+            MitsubishiCommands.LoopbackTest => 0x16,
+            _ => throw new NotSupportedException($"1E command {command:X4}/{subcommand:X4} is not supported in this release."),
+        };
+
+    private static byte ConvertPointCountToLegacyByte(int points)
+    {
+        if (points is < 1 or > 256)
+        {
+            throw new ArgumentOutOfRangeException(nameof(points), "1E point count must be between 1 and 256.");
+        }
+
+        return points == 256 ? (byte)0x00 : checked((byte)points);
+    }
+
+    private static void AppendByte(List<byte> buffer, byte value, CommunicationDataCode dataCode)
+    {
+        if (dataCode == CommunicationDataCode.Binary)
+        {
+            buffer.Add(value);
+            return;
+        }
+
+        foreach (var b in Encoding.ASCII.GetBytes(FormatAsciiByte(value)))
+        {
+            buffer.Add(b);
+        }
+    }
+
+    private static void AppendUInt16(List<byte> buffer, ushort value, CommunicationDataCode dataCode)
+    {
+        if (dataCode == CommunicationDataCode.Binary)
+        {
+            buffer.Add((byte)(value & 0xFF));
+            buffer.Add((byte)(value >> 8));
+            return;
+        }
+
+        foreach (var b in Encoding.ASCII.GetBytes(FormatAsciiUInt16(value)))
+        {
+            buffer.Add(b);
+        }
+    }
+
+    private static string FormatAsciiByte(byte value) => value.ToString("X2", CultureInfo.InvariantCulture);
+
+    private static string FormatAsciiUInt16(ushort value) => value.ToString("X4", CultureInfo.InvariantCulture);
+}

--- a/src/MitsubishiRx/MitsubishiRx.cs
+++ b/src/MitsubishiRx/MitsubishiRx.cs
@@ -1,355 +1,1911 @@
 ﻿// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Binary;
+using System.IO;
 using System.Net;
-using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using ReactiveUI.Extensions;
 
-namespace MitsubishiRx
+namespace MitsubishiRx;
+
+/// <summary>
+/// Reactive Mitsubishi Ethernet client supporting 1E, 3E, and 4E MC protocol / SLMP communication.
+/// </summary>
+public sealed class MitsubishiRx : IDisposable, IAsyncDisposable
 {
+    private readonly BehaviorSubject<MitsubishiConnectionState> _connectionStates = new(MitsubishiConnectionState.Disconnected);
+    private readonly Subject<MitsubishiOperationLog> _operationLogs = new();
+    private readonly SemaphoreSlim _requestGate = new(1, 1);
+    private readonly IMitsubishiTransport _transport;
+    private readonly IScheduler _scheduler;
+    private bool _disposed;
+
     /// <summary>
-    /// MitsubishiRx.
+    /// Initializes a new instance of the <see cref="MitsubishiRx"/> class using the legacy constructor shape.
     /// </summary>
-    public class MitsubishiRx : IDisposable
+    /// <param name="cpuType">CPU family hint.</param>
+    /// <param name="ip">Target PLC IP address or host name.</param>
+    /// <param name="port">Configured Ethernet port.</param>
+    /// <param name="timeout">Transport timeout in milliseconds.</param>
+    public MitsubishiRx(CpuType cpuType, string ip, int port, int timeout = 1500)
+        : this(new MitsubishiClientOptions(
+            ip,
+            port,
+            cpuType is CpuType.ASeries or CpuType.Fx3 ? MitsubishiFrameType.OneE : MitsubishiFrameType.ThreeE,
+            CommunicationDataCode.Binary,
+            MitsubishiTransportKind.Tcp,
+            Timeout: TimeSpan.FromMilliseconds(timeout),
+            CpuType: cpuType))
     {
-        private const int BufferSize = 4096;
-        private readonly object _lockObject = new();
-        private CpuType _cpuType;
-        private int _timeout;
-        private Socket _socket;
-        private bool _isAutoOpen = true;
-        private bool _disposedValue;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MitsubishiRx" /> class.
-        /// </summary>
-        /// <param name="cpuType">Type of the cpu.</param>
-        /// <param name="ip">The ip.</param>
-        /// <param name="port">The port.</param>
-        /// <param name="timeout">The timeout.</param>
-        public MitsubishiRx(CpuType cpuType, string ip, int port, int timeout = 1500)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MitsubishiRx"/> class.
+    /// </summary>
+    /// <param name="options">Client options.</param>
+    /// <param name="transport">Optional transport override.</param>
+    /// <param name="scheduler">Optional scheduler override for reactive streams.</param>
+    public MitsubishiRx(MitsubishiClientOptions options, IMitsubishiTransport? transport = null, IScheduler? scheduler = null)
+    {
+        Options = options ?? throw new ArgumentNullException(nameof(options));
+        _transport = transport ?? CreateDefaultTransport(options);
+        _scheduler = scheduler ?? Scheduler.Default;
+        if (options.TransportKind != MitsubishiTransportKind.Serial)
         {
-            _cpuType = cpuType;
-            if (!IPAddress.TryParse(ip, out var address))
+            _ = BuildEndPoint(options);
+        }
+    }
+
+    /// <summary>
+    /// Gets the configured options.
+    /// </summary>
+    public MitsubishiClientOptions Options { get; }
+
+    /// <summary>
+    /// Gets or sets the optional symbolic tag database used to resolve human-friendly tag names.
+    /// </summary>
+    public MitsubishiTagDatabase? TagDatabase { get; set; }
+
+    /// <summary>
+    /// Reads word devices using a configured tag name instead of a raw PLC address.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="points">Number of words to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read words.</returns>
+    public Task<Responce<ushort[]>> ReadWordsByTagAsync(string tagName, int points, CancellationToken cancellationToken = default)
+        => ReadWordsAsync(ResolveTagAddress(tagName), points, cancellationToken);
+
+    /// <summary>
+    /// Reads bit devices using a configured tag name instead of a raw PLC address.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="points">Number of bits to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read bit values.</returns>
+    public Task<Responce<bool[]>> ReadBitsByTagAsync(string tagName, int points, CancellationToken cancellationToken = default)
+        => ReadBitsAsync(ResolveTagAddress(tagName), points, cancellationToken);
+
+    /// <summary>
+    /// Writes word devices using a configured tag name instead of a raw PLC address.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="values">Values to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteWordsByTagAsync(string tagName, IReadOnlyList<ushort> values, CancellationToken cancellationToken = default)
+        => WriteWordsAsync(ResolveTagAddress(tagName), values, cancellationToken);
+
+    /// <summary>
+    /// Writes bit devices using a configured tag name instead of a raw PLC address.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="values">Bit values to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteBitsByTagAsync(string tagName, IReadOnlyList<bool> values, CancellationToken cancellationToken = default)
+        => WriteBitsAsync(ResolveTagAddress(tagName), values, cancellationToken);
+
+    /// <summary>
+    /// Executes a random word read using configured tag names instead of raw PLC addresses.
+    /// </summary>
+    /// <param name="tagNames">Configured tag names in request order.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read values in tag order.</returns>
+    public Task<Responce<ushort[]>> RandomReadWordsByTagAsync(IEnumerable<string> tagNames, CancellationToken cancellationToken = default)
+        => RandomReadWordsAsync(ResolveTagAddresses(tagNames), cancellationToken);
+
+    /// <summary>
+    /// Executes a random word write using configured tag names instead of raw PLC addresses.
+    /// </summary>
+    /// <param name="values">Tag/value pairs keyed by configured tag name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> RandomWriteWordsByTagAsync(IEnumerable<KeyValuePair<string, ushort>> values, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        return RandomWriteWordsAsync(values.Select(pair => new KeyValuePair<string, ushort>(ResolveTagAddress(pair.Key), pair.Value)), cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads a signed 16-bit integer using a configured tag name.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read signed 16-bit value.</returns>
+    public async Task<Responce<short>> ReadInt16ByTagAsync(string tagName, CancellationToken cancellationToken = default)
+    {
+        var raw = await ReadWordsByTagAsync(tagName, 1, cancellationToken).ConfigureAwait(false);
+        return ConvertWords(raw, words => unchecked((short)words[0]));
+    }
+
+    /// <summary>
+    /// Writes a signed 16-bit integer using a configured tag name.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="value">Value to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteInt16ByTagAsync(string tagName, short value, CancellationToken cancellationToken = default)
+        => WriteWordsByTagAsync(tagName, [unchecked((ushort)value)], cancellationToken);
+
+    /// <summary>
+    /// Reads an unsigned 16-bit integer using a configured tag name.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read unsigned 16-bit value.</returns>
+    public async Task<Responce<ushort>> ReadUInt16ByTagAsync(string tagName, CancellationToken cancellationToken = default)
+    {
+        var raw = await ReadWordsByTagAsync(tagName, 1, cancellationToken).ConfigureAwait(false);
+        return ConvertWords(raw, words => words[0]);
+    }
+
+    /// <summary>
+    /// Writes an unsigned 16-bit integer using a configured tag name.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="value">Value to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteUInt16ByTagAsync(string tagName, ushort value, CancellationToken cancellationToken = default)
+        => WriteWordsByTagAsync(tagName, [value], cancellationToken);
+
+    /// <summary>
+    /// Reads a signed 32-bit integer using a configured tag name.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read signed 32-bit value.</returns>
+    public async Task<Responce<int>> ReadInt32ByTagAsync(string tagName, CancellationToken cancellationToken = default)
+    {
+        var tag = GetRequiredTag(tagName);
+        var raw = await ReadWordsByTagAsync(tagName, 2, cancellationToken).ConfigureAwait(false);
+        return ConvertWords(raw, words => ConvertToInt32(words, tag));
+    }
+
+    /// <summary>
+    /// Writes a signed 32-bit integer using a configured tag name.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="value">Value to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteInt32ByTagAsync(string tagName, int value, CancellationToken cancellationToken = default)
+    {
+        var tag = GetRequiredTag(tagName);
+        return WriteWordsByTagAsync(tagName, ConvertFromInt32(value, tag), cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads a 32-bit unsigned value using a configured tag name.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read double-word value.</returns>
+    public async Task<Responce<uint>> ReadDWordByTagAsync(string tagName, CancellationToken cancellationToken = default)
+    {
+        var tag = GetRequiredTag(tagName);
+        var raw = await ReadWordsByTagAsync(tagName, 2, cancellationToken).ConfigureAwait(false);
+        return ConvertWords(raw, words => ConvertToUInt32(words, tag));
+    }
+
+    /// <summary>
+    /// Writes a 32-bit unsigned value using a configured tag name.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="value">Value to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteDWordByTagAsync(string tagName, uint value, CancellationToken cancellationToken = default)
+    {
+        var tag = GetRequiredTag(tagName);
+        return WriteWordsByTagAsync(tagName, ConvertFromUInt32(value, tag), cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads a 32-bit single-precision floating-point value using a configured tag name.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read floating-point value.</returns>
+    public async Task<Responce<float>> ReadFloatByTagAsync(string tagName, CancellationToken cancellationToken = default)
+    {
+        var tag = GetRequiredTag(tagName);
+        var raw = await ReadWordsByTagAsync(tagName, 2, cancellationToken).ConfigureAwait(false);
+        return ConvertWords(raw, words => ConvertToFloat(words, tag));
+    }
+
+    /// <summary>
+    /// Writes a 32-bit single-precision floating-point value using a configured tag name.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="value">Value to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteFloatByTagAsync(string tagName, float value, CancellationToken cancellationToken = default)
+    {
+        var tag = GetRequiredTag(tagName);
+        return WriteWordsByTagAsync(tagName, ConvertFromFloat(value, tag), cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads a scaled engineering value using the configured tag Scale and Offset metadata.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Scaled engineering value.</returns>
+    public async Task<Responce<double>> ReadScaledDoubleByTagAsync(string tagName, CancellationToken cancellationToken = default)
+    {
+        var tag = GetRequiredTag(tagName);
+        var wordCount = GetWordCountForScaledRead(tag);
+        var raw = await ReadWordsByTagAsync(tagName, wordCount, cancellationToken).ConfigureAwait(false);
+        return ConvertWords(raw, words => ApplyScaleAndOffset(ReadNumericTagValue(tag, words), tag));
+    }
+
+    /// <summary>
+    /// Writes a scaled engineering value using the configured tag Scale and Offset metadata.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="value">Engineering value to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteScaledDoubleByTagAsync(string tagName, double value, CancellationToken cancellationToken = default)
+    {
+        var tag = GetRequiredTag(tagName);
+        var rawValue = RemoveScaleAndOffset(value, tag);
+        return tag.DataType switch
+        {
+            null or "Word" => WriteWordsByTagAsync(tagName, [checked((ushort)Math.Round(rawValue, MidpointRounding.AwayFromZero))], cancellationToken),
+            "DWord" => WriteDWordByTagAsync(tagName, checked((uint)Math.Round(rawValue, MidpointRounding.AwayFromZero)), cancellationToken),
+            "Float" => WriteFloatByTagAsync(tagName, (float)rawValue, cancellationToken),
+            _ => Task.FromResult(new Responce().Fail($"Scaled access is not supported for tag '{tagName}' with DataType '{tag.DataType}'.")),
+        };
+    }
+
+    /// <summary>
+    /// Reads a PLC string stored across word devices using packed text bytes and the tag-configured length when available.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Decoded string.</returns>
+    public Task<Responce<string>> ReadStringByTagAsync(string tagName, CancellationToken cancellationToken = default)
+    {
+        var tag = GetRequiredTag(tagName);
+        var wordLength = tag.Length ?? throw new InvalidOperationException($"Tag '{tagName}' must define Length before ReadStringByTagAsync(tagName) can be used.");
+        return ReadStringByTagAsync(tagName, wordLength, cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads a PLC string stored across word devices using packed ASCII bytes.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="wordLength">Number of PLC words to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Decoded string.</returns>
+    public async Task<Responce<string>> ReadStringByTagAsync(string tagName, int wordLength, CancellationToken cancellationToken = default)
+    {
+        if (wordLength <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(wordLength));
+        }
+
+        var tag = GetRequiredTag(tagName);
+        var raw = await ReadWordsByTagAsync(tagName, wordLength, cancellationToken).ConfigureAwait(false);
+        return ConvertWords(raw, words => DecodeStringFromWords(words, tag));
+    }
+
+    /// <summary>
+    /// Writes a PLC string across word devices using the tag-configured length when available.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="value">String to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteStringByTagAsync(string tagName, string value, CancellationToken cancellationToken = default)
+    {
+        var tag = GetRequiredTag(tagName);
+        var wordLength = tag.Length ?? throw new InvalidOperationException($"Tag '{tagName}' must define Length before WriteStringByTagAsync(tagName, value) can be used.");
+        return WriteStringByTagAsync(tagName, value, wordLength, cancellationToken);
+    }
+
+    /// <summary>
+    /// Writes a PLC string across word devices using packed ASCII bytes.
+    /// </summary>
+    /// <param name="tagName">Configured tag name.</param>
+    /// <param name="value">String to write.</param>
+    /// <param name="wordLength">Number of PLC words to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteStringByTagAsync(string tagName, string value, int wordLength, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (wordLength <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(wordLength));
+        }
+
+        var tag = GetRequiredTag(tagName);
+        return WriteWordsByTagAsync(tagName, EncodeStringWords(value, wordLength, tag), cancellationToken);
+    }
+
+    /// <summary>
+    /// Validates the configured tag database and reports tag/group schema issues.
+    /// </summary>
+    /// <returns>Validation result.</returns>
+    public Responce ValidateTagDatabase()
+        => ValidateTagDatabase(TagDatabase);
+
+    /// <summary>
+    /// Loads a tag database from a schema file, validates it against the current client options, and assigns it when valid.
+    /// </summary>
+    /// <param name="path">Schema file path.</param>
+    /// <returns>Validation result with the loaded database when successful.</returns>
+    public Responce<MitsubishiTagDatabase> LoadAndValidateTagDatabase(string path)
+        => LoadAndValidateTagDatabase(path, MitsubishiTagRolloutPolicy.AllowAll);
+
+    /// <summary>
+    /// Loads a tag database from a schema file, validates it, enforces rollout policy, and assigns it when valid.
+    /// </summary>
+    /// <param name="path">Schema file path.</param>
+    /// <param name="policy">Rollout policy.</param>
+    /// <returns>Validation result with the loaded database when successful.</returns>
+    public Responce<MitsubishiTagDatabase> LoadAndValidateTagDatabase(string path, MitsubishiTagRolloutPolicy policy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        try
+        {
+            var database = MitsubishiTagDatabase.Load(path);
+            var validation = ValidateTagDatabase(database);
+            if (!validation.IsSucceed)
             {
-                address = Dns.GetHostEntry(ip).AddressList?.FirstOrDefault();
+                return new Responce<MitsubishiTagDatabase>(validation);
             }
 
-            IpEndPoint = new IPEndPoint(address, port);
-            _timeout = timeout;
-        }
-
-        /// <summary>
-        /// Gets the ip end point.
-        /// </summary>
-        /// <value>
-        /// The ip end point.
-        /// </value>
-        public IPEndPoint IpEndPoint { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether this <see cref="MitsubishiRx"/> is connected.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if connected; otherwise, <c>false</c>.
-        /// </value>
-        public bool Connected => _socket?.Connected ?? false;
-
-        /// <summary>
-        /// Opens this instance.
-        /// </summary>
-        /// <returns>Responce.</returns>
-        public Responce Open()
-        {
-            _isAutoOpen = false;
-            return Connect();
-        }
-
-        /// <summary>
-        /// Closes this instance.
-        /// </summary>
-        /// <returns>Responce.</returns>
-        public Responce Close()
-        {
-            _isAutoOpen = true;
-            return DisposeSocket();
-        }
-
-        /// <summary>
-        /// Sends the package single.
-        /// </summary>
-        /// <param name="command">The command.</param>
-        /// <returns>Responce.</returns>
-        public Responce<byte[]> SendPackageSingle(byte[] command)
-        {
-            lock (_lockObject)
+            var diff = (TagDatabase ?? new MitsubishiTagDatabase(Array.Empty<MitsubishiTagDefinition>())).CompareWith(database);
+            var policyResult = ValidateRolloutPolicy(diff, policy);
+            if (!policyResult.IsSucceed)
             {
-                var result = new Responce<byte[]>();
-                try
-                {
-                    _socket.Send(command);
-                    var socketReadResul = MitsubishiRx.SocketRead(_socket, 9);
-                    if (!socketReadResul.IsSucceed)
-                    {
-                        return socketReadResul;
-                    }
-
-                    var headPackage = socketReadResul.Value;
-
-                    var contentLength = BitConverter.ToUInt16(headPackage, 7);
-                    socketReadResul = MitsubishiRx.SocketRead(_socket, contentLength);
-                    if (!socketReadResul.IsSucceed)
-                    {
-                        return socketReadResul;
-                    }
-
-                    var dataPackage = socketReadResul.Value;
-
-                    result.Value = headPackage.Concat(dataPackage).ToArray();
-                    return result.EndTime();
-                }
-                catch (Exception ex)
-                {
-                    result.IsSucceed = false;
-                    result.Err = ex.Message;
-                    result.AddErr2List();
-                    return result.EndTime();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Sends the package.
-        /// </summary>
-        /// <param name="command">The command.</param>
-        /// <param name="receiveCount">The receive count.</param>
-        /// <returns>Responce.</returns>
-        public Responce<byte[]> SendPackage(byte[] command, int receiveCount)
-        {
-            Responce<byte[]> GetResponce()
-            {
-                lock (_lockObject)
-                {
-                    var result = new Responce<byte[]>();
-                    _socket.Send(command);
-                    var socketReadResul = MitsubishiRx.SocketRead(_socket, receiveCount);
-                    if (!socketReadResul.IsSucceed)
-                    {
-                        return socketReadResul;
-                    }
-
-                    var dataPackage = socketReadResul.Value;
-
-                    result.Value = dataPackage.ToArray();
-                    return result.EndTime();
-                }
+                return new Responce<MitsubishiTagDatabase>(policyResult, database);
             }
 
+            TagDatabase = database;
+            return new Responce<MitsubishiTagDatabase>(policyResult, database);
+        }
+        catch (Exception ex)
+        {
+            return new Responce<MitsubishiTagDatabase>().Fail(ex.Message, exception: ex);
+        }
+    }
+
+    /// <summary>
+    /// Loads a tag database from a schema file, validates it, and compares it to the current active schema without applying it.
+    /// </summary>
+    /// <param name="path">Schema file path.</param>
+    /// <returns>Semantic schema diff.</returns>
+    public Responce<MitsubishiTagDatabaseDiff> PreviewTagDatabaseDiff(string path)
+        => PreviewTagDatabaseDiff(path, MitsubishiTagRolloutPolicy.AllowAll);
+
+    /// <summary>
+    /// Loads a tag database from a schema file, validates it, compares it to the current active schema, and evaluates rollout policy without applying it.
+    /// </summary>
+    /// <param name="path">Schema file path.</param>
+    /// <param name="policy">Rollout policy.</param>
+    /// <returns>Semantic schema diff.</returns>
+    public Responce<MitsubishiTagDatabaseDiff> PreviewTagDatabaseDiff(string path, MitsubishiTagRolloutPolicy policy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        try
+        {
+            var database = MitsubishiTagDatabase.Load(path);
+            var validation = ValidateTagDatabase(database);
+            if (!validation.IsSucceed)
+            {
+                return new Responce<MitsubishiTagDatabaseDiff>(validation);
+            }
+
+            var diff = (TagDatabase ?? new MitsubishiTagDatabase(Array.Empty<MitsubishiTagDefinition>())).CompareWith(database);
+            var policyResult = ValidateRolloutPolicy(diff, policy);
+            return new Responce<MitsubishiTagDatabaseDiff>(policyResult, diff);
+        }
+        catch (Exception ex)
+        {
+            return new Responce<MitsubishiTagDatabaseDiff>().Fail(ex.Message, exception: ex);
+        }
+    }
+
+    /// <summary>
+    /// Periodically reloads a schema file, validates it, and emits semantic diffs against the last active schema.
+    /// Successful reloads replace <see cref="TagDatabase"/>; failed reloads leave the current database unchanged.
+    /// </summary>
+    /// <param name="path">Schema file path.</param>
+    /// <param name="pollInterval">Polling interval for change detection.</param>
+    /// <param name="emitInitial">If true, emits immediately before waiting for the first interval.</param>
+    /// <returns>Observable diff results.</returns>
+    public IObservable<Responce<MitsubishiTagDatabaseDiff>> ObserveTagDatabaseDiff(string path, TimeSpan pollInterval, bool emitInitial = true)
+        => ObserveTagDatabaseDiff(path, pollInterval, emitInitial, MitsubishiTagRolloutPolicy.AllowAll);
+
+    /// <summary>
+    /// Periodically reloads a schema file, validates it, and emits semantic diffs against the last active schema.
+    /// Successful reloads replace <see cref="TagDatabase"/> when permitted by the rollout policy.
+    /// </summary>
+    /// <param name="path">Schema file path.</param>
+    /// <param name="pollInterval">Polling interval for change detection.</param>
+    /// <param name="emitInitial">If true, emits immediately before waiting for the first interval.</param>
+    /// <param name="policy">Rollout policy.</param>
+    /// <returns>Observable diff results.</returns>
+    public IObservable<Responce<MitsubishiTagDatabaseDiff>> ObserveTagDatabaseDiff(string path, TimeSpan pollInterval, bool emitInitial, MitsubishiTagRolloutPolicy policy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        if (pollInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pollInterval));
+        }
+
+        var ticks = Observable.Interval(pollInterval, _scheduler);
+        var trigger = emitInitial ? ticks.StartWith(0L) : ticks;
+        string? lastFingerprint = null;
+
+        return trigger
+            .Select(_ => GetSchemaFingerprint(path))
+            .Where(fingerprint => !string.Equals(fingerprint, lastFingerprint, StringComparison.Ordinal))
+            .Do(fingerprint => lastFingerprint = fingerprint)
+            .Select(_ =>
+            {
+                var preview = PreviewTagDatabaseDiff(path, policy);
+                if (!preview.IsSucceed)
+                {
+                    return preview;
+                }
+
+                var load = LoadAndValidateTagDatabase(path, policy);
+                return load.IsSucceed && preview.Value is not null
+                    ? new Responce<MitsubishiTagDatabaseDiff>(load, preview.Value)
+                    : new Responce<MitsubishiTagDatabaseDiff>(preview);
+            })
+            .DoOnSubscribe(() => PublishOperation($"Observe tag database diff {path} subscribed", true, Array.Empty<byte>(), Array.Empty<byte>()))
+            .DoOnDispose(() => PublishOperation($"Observe tag database diff {path} disposed", true, Array.Empty<byte>(), Array.Empty<byte>()));
+    }
+
+    /// <summary>
+    /// Periodically reloads a schema file, validates it, and emits the latest load result.
+    /// Successful reloads replace <see cref="TagDatabase"/>; failed reloads leave the current database unchanged.
+    /// </summary>
+    /// <param name="path">Schema file path.</param>
+    /// <param name="pollInterval">Polling interval for change detection.</param>
+    /// <param name="emitInitial">If true, emits immediately before waiting for the first interval.</param>
+    /// <returns>Observable reload results.</returns>
+    public IObservable<Responce<MitsubishiTagDatabase>> ObserveTagDatabaseReload(string path, TimeSpan pollInterval, bool emitInitial = true)
+        => ObserveTagDatabaseReload(path, pollInterval, emitInitial, MitsubishiTagRolloutPolicy.AllowAll);
+
+    /// <summary>
+    /// Periodically reloads a schema file, validates it, and emits the latest load result subject to rollout policy.
+    /// Successful reloads replace <see cref="TagDatabase"/> when permitted; failed reloads leave the current database unchanged.
+    /// </summary>
+    /// <param name="path">Schema file path.</param>
+    /// <param name="pollInterval">Polling interval for change detection.</param>
+    /// <param name="emitInitial">If true, emits immediately before waiting for the first interval.</param>
+    /// <param name="policy">Rollout policy.</param>
+    /// <returns>Observable reload results.</returns>
+    public IObservable<Responce<MitsubishiTagDatabase>> ObserveTagDatabaseReload(string path, TimeSpan pollInterval, bool emitInitial, MitsubishiTagRolloutPolicy policy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        if (pollInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pollInterval));
+        }
+
+        var ticks = Observable.Interval(pollInterval, _scheduler);
+        var trigger = emitInitial ? ticks.StartWith(0L) : ticks;
+        string? lastFingerprint = null;
+
+        return trigger
+            .Select(_ => GetSchemaFingerprint(path))
+            .Where(fingerprint => !string.Equals(fingerprint, lastFingerprint, StringComparison.Ordinal))
+            .Do(fingerprint => lastFingerprint = fingerprint)
+            .Select(_ => LoadAndValidateTagDatabase(path, policy))
+            .DoOnSubscribe(() => PublishOperation($"Observe tag database reload {path} subscribed", true, Array.Empty<byte>(), Array.Empty<byte>()))
+            .DoOnDispose(() => PublishOperation($"Observe tag database reload {path} disposed", true, Array.Empty<byte>(), Array.Empty<byte>()));
+    }
+
+    private Responce ValidateTagDatabase(MitsubishiTagDatabase? database)
+    {
+        var result = new Responce();
+        if (database is null)
+        {
+            return result.Fail("TagDatabase must be assigned before validation can run.");
+        }
+
+        foreach (var tag in database.Tags)
+        {
             try
             {
-                var result = GetResponce();
-                if (!result.IsSucceed)
-                {
-                    //// WarningLog?.Invoke(result.Err, result.Exception);
-                    var conentResult = Connect();
-                    if (!conentResult.IsSucceed)
-                    {
-                        return new Responce<byte[]>(conentResult);
-                    }
-
-                    return GetResponce();
-                }
-
-                return result;
+                _ = MitsubishiDeviceAddress.Parse(tag.Address, Options.XyNotation);
             }
             catch (Exception ex)
-            {
-                //// WarningLog?.Invoke(ex.Message, ex);
-                var conentResult = Connect();
-                if (!conentResult.IsSucceed)
-                {
-                    return new Responce<byte[]>(conentResult);
-                }
-
-                return GetResponce();
-            }
-        }
-
-        /// <summary>
-        /// Sends the package reliable.
-        /// </summary>
-        /// <param name="command">The command.</param>
-        /// <returns>Responce.</returns>
-        public Responce<byte[]> SendPackageReliable(byte[] command)
-        {
-            try
-            {
-                var result = SendPackageSingle(command);
-                if (!result.IsSucceed)
-                {
-                    //// WarningLog?.Invoke(result.Err, result.Exception);
-                    var conentResult = Connect();
-                    if (!conentResult.IsSucceed)
-                    {
-                        return new Responce<byte[]>(conentResult);
-                    }
-
-                    return SendPackageSingle(command);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                try
-                {
-                    //// WarningLog?.Invoke(ex.Message, ex);
-                    var conentResult = Connect();
-                    if (!conentResult.IsSucceed)
-                    {
-                        return new Responce<byte[]>(conentResult);
-                    }
-
-                    return SendPackageSingle(command);
-                }
-                catch (Exception ex2)
-                {
-                    var result = new Responce<byte[]>();
-                    result.IsSucceed = false;
-                    result.Err = ex2.Message;
-                    result.AddErr2List();
-                    return result.EndTime();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Releases unmanaged and - optionally - managed resources.
-        /// </summary>
-        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                if (disposing)
-                {
-                    _socket.Dispose();
-                }
-
-                _disposedValue = true;
-            }
-        }
-
-        private static Responce<byte[]> SocketRead(Socket socket, int receiveCount)
-        {
-            var result = new Responce<byte[]>();
-            if (receiveCount < 0)
             {
                 result.IsSucceed = false;
-                result.Err = $"Read length : {receiveCount}";
-                result.AddErr2List();
-                return result;
+                result.ErrList.Add($"Tag '{tag.Name}' has invalid Address '{tag.Address}': {ex.Message}");
             }
 
-            var receiveBytes = new byte[receiveCount];
-            var receiveFinish = 0;
-            while (receiveFinish < receiveCount)
+            if (string.Equals(tag.DataType, "String", StringComparison.OrdinalIgnoreCase) && (!tag.Length.HasValue || tag.Length.Value <= 0))
             {
-                var receiveLength = (receiveCount - receiveFinish) >= BufferSize ? BufferSize : (receiveCount - receiveFinish);
-                try
-                {
-                    var readLeng = socket.Receive(receiveBytes, receiveFinish, receiveLength, SocketFlags.None);
-                    if (readLeng == 0)
-                    {
-                        socket?.SafeClose();
-                        result.IsSucceed = false;
-                        result.Err = "the connection dropped";
-                        result.AddErr2List();
-                        return result;
-                    }
+                result.IsSucceed = false;
+                result.ErrList.Add($"Tag '{tag.Name}' uses DataType 'String' and must define a positive Length.");
+            }
+        }
 
-                    receiveFinish += readLeng;
-                }
-                catch (SocketException ex)
+        foreach (var group in database.Groups)
+        {
+            foreach (var tagName in group.ResolvedTagNames)
+            {
+                if (!database.TryGet(tagName, out _))
                 {
-                    socket?.SafeClose();
-                    if (ex.SocketErrorCode == SocketError.TimedOut)
-                    {
-                        result.Err = $"Connection timed out：{ex.Message}";
-                    }
-                    else
-                    {
-                        result.Err = $"The connection dropped，{ex.Message}";
-                    }
-
                     result.IsSucceed = false;
-                    result.AddErr2List();
-                    result.Exception = ex;
-                    return result;
+                    result.ErrList.Add($"Group '{group.Name}' references unknown tag '{tagName}'.");
                 }
             }
+        }
 
-            result.Value = receiveBytes;
+        if (!result.IsSucceed && result.ErrList.Count > 0)
+        {
+            result.Err = string.Join(Environment.NewLine, result.ErrList);
+        }
+
+        return result.EndTime();
+    }
+
+    /// <summary>
+    /// Reads a heterogeneous snapshot for all tags in a configured group.
+    /// </summary>
+    /// <param name="groupName">Configured group name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Grouped snapshot values.</returns>
+    public async Task<Responce<MitsubishiTagGroupSnapshot>> ReadTagGroupSnapshotAsync(string groupName, CancellationToken cancellationToken = default)
+    {
+        var database = TagDatabase ?? throw new InvalidOperationException("TagDatabase must be assigned before tag-based APIs can be used.");
+        var group = database.GetRequiredGroup(groupName);
+        var values = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tagName in group.ResolvedTagNames)
+        {
+            var valueResult = await ReadTagValueAsync(tagName, cancellationToken).ConfigureAwait(false);
+            if (!valueResult.IsSucceed)
+            {
+                return new Responce<MitsubishiTagGroupSnapshot>(valueResult);
+            }
+
+            values[tagName] = valueResult.Value;
+        }
+
+        return new Responce<MitsubishiTagGroupSnapshot>(new MitsubishiTagGroupSnapshot(group.Name, values));
+    }
+
+    /// <summary>
+    /// Validates a pending grouped write payload against the configured tag schema.
+    /// </summary>
+    /// <param name="groupName">Configured group name.</param>
+    /// <param name="values">Pending values keyed by tag name.</param>
+    /// <returns>Validation result.</returns>
+    public Responce ValidateTagGroupWrite(string groupName, IReadOnlyDictionary<string, object?> values)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupName);
+        ArgumentNullException.ThrowIfNull(values);
+        var result = new Responce();
+        var database = TagDatabase;
+        if (database is null)
+        {
+            return result.Fail("TagDatabase must be assigned before grouped writes can be validated.");
+        }
+
+        var group = database.GetRequiredGroup(groupName);
+        var allowed = new HashSet<string>(group.ResolvedTagNames, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var pair in values)
+        {
+            if (!allowed.Contains(pair.Key))
+            {
+                result.IsSucceed = false;
+                result.ErrList.Add($"Group '{groupName}' does not contain tag '{pair.Key}'.");
+                continue;
+            }
+
+            var tag = database.GetRequired(pair.Key);
+            if (!CanWriteTagValue(tag, pair.Value, out var error))
+            {
+                result.IsSucceed = false;
+                result.ErrList.Add(error!);
+            }
+        }
+
+        if (!result.IsSucceed && result.ErrList.Count > 0)
+        {
+            result.Err = string.Join(Environment.NewLine, result.ErrList);
+        }
+
+        return result.EndTime();
+    }
+
+    /// <summary>
+    /// Writes the provided subset of values for a configured group.
+    /// </summary>
+    /// <param name="groupName">Configured group name.</param>
+    /// <param name="values">Values keyed by tag name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public async Task<Responce> WriteTagGroupValuesAsync(string groupName, IReadOnlyDictionary<string, object?> values, CancellationToken cancellationToken = default)
+    {
+        var validation = ValidateTagGroupWrite(groupName, values);
+        if (!validation.IsSucceed)
+        {
+            return validation;
+        }
+
+        var group = GetRequiredTagDatabase().GetRequiredGroup(groupName);
+        foreach (var tagName in group.ResolvedTagNames)
+        {
+            if (!values.TryGetValue(tagName, out var value))
+            {
+                continue;
+            }
+
+            var write = await WriteTagValueAsync(tagName, value, cancellationToken).ConfigureAwait(false);
+            if (!write.IsSucceed)
+            {
+                return write;
+            }
+        }
+
+        return new Responce().EndTime();
+    }
+
+    /// <summary>
+    /// Writes all values contained in a grouped snapshot.
+    /// </summary>
+    /// <param name="snapshot">Grouped snapshot.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> WriteTagGroupSnapshotAsync(MitsubishiTagGroupSnapshot snapshot, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        return WriteTagGroupValuesAsync(snapshot.GroupName, new Dictionary<string, object?>(snapshot.Values, StringComparer.OrdinalIgnoreCase), cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the underlying transport is connected.
+    /// </summary>
+    public bool Connected => _transport.IsConnected;
+
+    /// <summary>
+    /// Gets a reactive stream of connection state transitions.
+    /// </summary>
+    public IObservable<MitsubishiConnectionState> ConnectionStates => _connectionStates.AsObservable().DistinctUntilChanged();
+
+    /// <summary>
+    /// Gets a reactive stream of operation logs.
+    /// </summary>
+    public IObservable<MitsubishiOperationLog> OperationLogs => _operationLogs.AsObservable();
+
+    /// <summary>
+    /// Opens the underlying transport.
+    /// </summary>
+    /// <returns>Operation result.</returns>
+    public Responce Open() => OpenAsync().GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Opens the underlying transport asynchronously.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public async Task<Responce> OpenAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var result = new Responce();
+        try
+        {
+            await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false);
             return result.EndTime();
         }
-
-        private Responce Connect()
+        catch (Exception ex)
         {
-            var result = new Responce();
-            _socket?.SafeClose();
-            _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            try
-            {
-                _socket.ReceiveTimeout = _timeout;
-                _socket.SendTimeout = _timeout;
-                var connectResult = _socket.BeginConnect(IpEndPoint, null, null);
-                if (!connectResult.AsyncWaitHandle.WaitOne(_timeout))
-                {
-                    throw new TimeoutException("Connection timed out");
-                }
+            PublishFault("Open transport", Array.Empty<byte>(), Array.Empty<byte>(), ex);
+            return result.Fail(ex.Message, exception: ex);
+        }
+    }
 
-                _socket.EndConnect(connectResult);
-            }
-            catch (Exception ex)
-            {
-                _socket?.SafeClose();
-                result.IsSucceed = false;
-                result.Err = ex.Message;
-                result.ErrCode = 408;
-                result.Exception = ex;
-            }
+    /// <summary>
+    /// Closes the underlying transport.
+    /// </summary>
+    /// <returns>Operation result.</returns>
+    public Responce Close() => CloseAsync().GetAwaiter().GetResult();
 
+    /// <summary>
+    /// Closes the underlying transport asynchronously.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public async Task<Responce> CloseAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var result = new Responce();
+        try
+        {
+            await _transport.DisconnectAsync(cancellationToken).ConfigureAwait(false);
+            PublishState(MitsubishiConnectionState.Disconnected);
+            PublishOperation("Close transport", true, Array.Empty<byte>(), Array.Empty<byte>());
             return result.EndTime();
         }
-
-        /// <summary>
-        /// Releases unmanaged and - optionally - managed resources.
-        /// </summary>
-        /// <returns>Responce.</returns>
-        private Responce DisposeSocket()
+        catch (Exception ex)
         {
-            var result = new Responce();
-            try
+            PublishFault("Close transport", Array.Empty<byte>(), Array.Empty<byte>(), ex);
+            return result.Fail(ex.Message, exception: ex);
+        }
+    }
+
+    /// <summary>
+    /// Sends an already encoded request and reads a fixed-size response.
+    /// </summary>
+    /// <param name="command">Encoded request bytes.</param>
+    /// <param name="receiveCount">Expected response length.</param>
+    /// <returns>Raw response bytes.</returns>
+    public Responce<byte[]> SendPackage(byte[] command, int receiveCount)
+        => ExecuteEncodedAsync(command, receiveCount, "Legacy raw package").GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Sends an already encoded request and reads a frame-sized response.
+    /// </summary>
+    /// <param name="command">Encoded request bytes.</param>
+    /// <returns>Raw response bytes.</returns>
+    public Responce<byte[]> SendPackageSingle(byte[] command)
+        => ExecuteEncodedAsync(command, null, "Legacy raw package single").GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Sends an already encoded request and retries transient transport failures with backoff.
+    /// </summary>
+    /// <param name="command">Encoded request bytes.</param>
+    /// <returns>Raw response bytes.</returns>
+    public Responce<byte[]> SendPackageReliable(byte[] command)
+        => ExecuteEncodedAsync(command, null, "Legacy raw package reliable", maxRetries: 2).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Executes a low-level MC protocol / SLMP command.
+    /// </summary>
+    /// <param name="request">Command request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Raw decoded response payload.</returns>
+    public Task<Responce<byte[]>> ExecuteRawAsync(MitsubishiRawCommandRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return ExecuteObservableAsync(
+            () => Options.TransportKind == MitsubishiTransportKind.Serial
+                ? throw new NotSupportedException("Raw serial execution is not yet implemented for 1C/3C/4C commands.")
+                : MitsubishiProtocolEncoding.Encode(Options, request),
+            Options.TransportKind == MitsubishiTransportKind.Serial
+                ? null
+                : MitsubishiProtocolEncoding.GetFixedResponseLength(Options.FrameType, Options.DataCode, request.Command, request.Subcommand, request.ResolvedBody.Count),
+            request.Description ?? $"Command {request.Command:X4}",
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads word devices using batch access.
+    /// </summary>
+    /// <param name="address">Device address.</param>
+    /// <param name="points">Number of words to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read words.</returns>
+    public async Task<Responce<ushort[]>> ReadWordsAsync(string address, int points, CancellationToken cancellationToken = default)
+    {
+        var parsed = MitsubishiDeviceAddress.Parse(address, Options.XyNotation);
+        var raw = await ExecuteObservableAsync(
+            () => Options.TransportKind == MitsubishiTransportKind.Serial
+                ? MitsubishiSerialProtocolEncoding.EncodeWordReadRequest(Options, parsed, points)
+                : MitsubishiProtocolEncoding.EncodeDeviceBatchRead(Options, parsed, points, bitUnits: false),
+            Options.TransportKind == MitsubishiTransportKind.Serial
+                ? null
+                : Options.FrameType == MitsubishiFrameType.OneE ? 2 + (points * 2) : null,
+            $"Read words {address}",
+            cancellationToken).ConfigureAwait(false);
+        return ParseWords(raw, Options.TransportKind == MitsubishiTransportKind.Serial ? points : null);
+    }
+
+    /// <summary>
+    /// Writes word devices using batch access.
+    /// </summary>
+    /// <param name="address">Device address.</param>
+    /// <param name="values">Values to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public async Task<Responce> WriteWordsAsync(string address, IReadOnlyList<ushort> values, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        var parsed = MitsubishiDeviceAddress.Parse(address, Options.XyNotation);
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeDeviceBatchWrite(Options, parsed, values.ToArray(), bitUnits: false),
+            Options.FrameType == MitsubishiFrameType.OneE ? 2 : null,
+            $"Write words {address}",
+            cancellationToken).ConfigureAwait(false);
+        return raw.ToBaseResponse();
+    }
+
+    /// <summary>
+    /// Reads bit devices using batch access.
+    /// </summary>
+    /// <param name="address">Device address.</param>
+    /// <param name="points">Number of bit points to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read bit values.</returns>
+    public async Task<Responce<bool[]>> ReadBitsAsync(string address, int points, CancellationToken cancellationToken = default)
+    {
+        var parsed = MitsubishiDeviceAddress.Parse(address, Options.XyNotation);
+        int? expected = Options.FrameType == MitsubishiFrameType.OneE ? 2 + ((points + 1) / 2) : null;
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeDeviceBatchRead(Options, parsed, points, bitUnits: true),
+            expected,
+            $"Read bits {address}",
+            cancellationToken).ConfigureAwait(false);
+        return ParseBits(raw, points);
+    }
+
+    /// <summary>
+    /// Writes bit devices using batch access.
+    /// </summary>
+    /// <param name="address">Device address.</param>
+    /// <param name="values">Bit values to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public async Task<Responce> WriteBitsAsync(string address, IReadOnlyList<bool> values, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        var parsed = MitsubishiDeviceAddress.Parse(address, Options.XyNotation);
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeDeviceBatchWrite(Options, parsed, values.Select(static v => v ? (ushort)1 : (ushort)0).ToArray(), bitUnits: true),
+            Options.FrameType == MitsubishiFrameType.OneE ? 2 : null,
+            $"Write bits {address}",
+            cancellationToken).ConfigureAwait(false);
+        return raw.ToBaseResponse();
+    }
+
+    /// <summary>
+    /// Executes a random read for word devices.
+    /// </summary>
+    /// <param name="addresses">Addresses to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read values in request order.</returns>
+    public async Task<Responce<ushort[]>> RandomReadWordsAsync(IEnumerable<string> addresses, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(addresses);
+        var parsed = addresses.Select(address => MitsubishiDeviceAddress.Parse(address, Options.XyNotation)).ToArray();
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeRandomRead(Options, parsed),
+            null,
+            "Random read words",
+            cancellationToken).ConfigureAwait(false);
+        return ParseWords(raw);
+    }
+
+    /// <summary>
+    /// Executes a random write for word devices.
+    /// </summary>
+    /// <param name="values">Values to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public async Task<Responce> RandomWriteWordsAsync(IEnumerable<KeyValuePair<string, ushort>> values, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        var payload = values.Select(pair => new MitsubishiDeviceValue(MitsubishiDeviceAddress.Parse(pair.Key, Options.XyNotation), pair.Value)).ToArray();
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeRandomWrite(Options, payload),
+            null,
+            "Random write words",
+            cancellationToken).ConfigureAwait(false);
+        return raw.ToBaseResponse();
+    }
+
+    /// <summary>
+    /// Registers monitor devices for subsequent execute-monitor calls.
+    /// </summary>
+    /// <param name="addresses">Word device addresses to monitor.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public async Task<Responce> RegisterMonitorAsync(IEnumerable<string> addresses, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(addresses);
+        var payload = addresses.Select(address => MitsubishiDeviceAddress.Parse(address, Options.XyNotation)).ToArray();
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeMonitorRegistration(Options, payload),
+            null,
+            "Register monitor",
+            cancellationToken).ConfigureAwait(false);
+        return raw.ToBaseResponse();
+    }
+
+    /// <summary>
+    /// Executes a previously registered monitor operation.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Raw monitor payload.</returns>
+    public Task<Responce<byte[]>> ExecuteMonitorAsync(CancellationToken cancellationToken = default)
+        => ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeExecuteMonitor(Options),
+            null,
+            "Execute monitor",
+            cancellationToken);
+
+    /// <summary>
+    /// Executes a block read request.
+    /// </summary>
+    /// <param name="request">Block request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Raw block response bytes.</returns>
+    public Task<Responce<byte[]>> ReadBlocksAsync(MitsubishiBlockRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeBlockRead(Options, request),
+            null,
+            "Block read",
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes a block write request.
+    /// </summary>
+    /// <param name="request">Block request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public async Task<Responce> WriteBlocksAsync(MitsubishiBlockRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeBlockWrite(Options, request),
+            null,
+            "Block write",
+            cancellationToken).ConfigureAwait(false);
+        return raw.ToBaseResponse();
+    }
+
+    /// <summary>
+    /// Reads the PLC type name and model code.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Type information.</returns>
+    public async Task<Responce<MitsubishiTypeName>> ReadTypeNameAsync(CancellationToken cancellationToken = default)
+    {
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeReadTypeName(Options),
+            null,
+            "Read type name",
+            cancellationToken).ConfigureAwait(false);
+        return ParseTypeName(raw);
+    }
+
+    /// <summary>
+    /// Performs a remote RUN request.
+    /// </summary>
+    /// <param name="force">Whether forced mode should be requested.</param>
+    /// <param name="clearMode">Whether clear mode should be requested.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> RemoteRunAsync(bool force = true, bool clearMode = false, CancellationToken cancellationToken = default)
+        => ExecuteControlAsync(MitsubishiCommands.RemoteRun, cancellationToken, force, clearMode);
+
+    /// <summary>
+    /// Performs a remote STOP request.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> RemoteStopAsync(CancellationToken cancellationToken = default)
+        => ExecuteControlAsync(MitsubishiCommands.RemoteStop, cancellationToken);
+
+    /// <summary>
+    /// Performs a remote PAUSE request.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> RemotePauseAsync(CancellationToken cancellationToken = default)
+        => ExecuteControlAsync(MitsubishiCommands.RemotePause, cancellationToken);
+
+    /// <summary>
+    /// Performs a remote latch clear request.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> RemoteLatchClearAsync(CancellationToken cancellationToken = default)
+        => ExecuteControlAsync(MitsubishiCommands.RemoteLatchClear, cancellationToken);
+
+    /// <summary>
+    /// Performs a remote reset request.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> RemoteResetAsync(CancellationToken cancellationToken = default)
+        => ExecuteControlAsync(MitsubishiCommands.RemoteReset, cancellationToken);
+
+    /// <summary>
+    /// Unlocks the PLC using the configured remote password facility.
+    /// </summary>
+    /// <param name="password">Remote password.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> UnlockAsync(string password, CancellationToken cancellationToken = default)
+        => ExecutePasswordAsync(MitsubishiCommands.Unlock, password, cancellationToken);
+
+    /// <summary>
+    /// Locks the PLC using the configured remote password facility.
+    /// </summary>
+    /// <param name="password">Remote password.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public Task<Responce> LockAsync(string password, CancellationToken cancellationToken = default)
+        => ExecutePasswordAsync(MitsubishiCommands.Lock, password, cancellationToken);
+
+    /// <summary>
+    /// Clears the error state on the target PLC or Ethernet module.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public async Task<Responce> ClearErrorAsync(CancellationToken cancellationToken = default)
+    {
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.Encode(Options, new MitsubishiRawCommandRequest(MitsubishiCommands.ClearError, 0x0000, Array.Empty<byte>(), "Clear error")),
+            null,
+            "Clear error",
+            cancellationToken).ConfigureAwait(false);
+        return raw.ToBaseResponse();
+    }
+
+    /// <summary>
+    /// Executes a loopback self-test against the PLC or Ethernet module.
+    /// </summary>
+    /// <param name="data">Loopback data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Looped-back payload.</returns>
+    public async Task<Responce<byte[]>> LoopbackAsync(byte[] data, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        int? expected = Options.FrameType == MitsubishiFrameType.OneE ? 4 + data.Length : null;
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeLoopback(Options, data),
+            expected,
+            "Loopback",
+            cancellationToken).ConfigureAwait(false);
+        return raw;
+    }
+
+    /// <summary>
+    /// Reads raw memory / buffer data from the own station or an intelligent module.
+    /// </summary>
+    /// <param name="command">Read command to execute.</param>
+    /// <param name="address">Start address.</param>
+    /// <param name="length">Number of words.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Read words.</returns>
+    public async Task<Responce<ushort[]>> ReadMemoryAsync(ushort command, ushort address, int length, CancellationToken cancellationToken = default)
+    {
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeMemoryAccess(Options, command, address, length, Array.Empty<ushort>()),
+            null,
+            $"Read memory {command:X4}",
+            cancellationToken).ConfigureAwait(false);
+        return ParseWords(raw, expectedWordCount: length);
+    }
+
+    /// <summary>
+    /// Writes raw memory / buffer data to the own station or an intelligent module.
+    /// </summary>
+    /// <param name="command">Write command to execute.</param>
+    /// <param name="address">Start address.</param>
+    /// <param name="values">Values to write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Operation result.</returns>
+    public async Task<Responce> WriteMemoryAsync(ushort command, ushort address, IReadOnlyList<ushort> values, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeMemoryAccess(Options, command, address, values.Count, values.ToArray()),
+            null,
+            $"Write memory {command:X4}",
+            cancellationToken).ConfigureAwait(false);
+        return raw.ToBaseResponse();
+    }
+
+    /// <summary>
+    /// Continuously polls a word range and emits sequential results.
+    /// </summary>
+    /// <param name="address">Device address.</param>
+    /// <param name="points">Number of words.</param>
+    /// <param name="pollInterval">Polling interval.</param>
+    /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
+    /// <param name="pollTimeout">Per-poll timeout.</param>
+    /// <returns>Observable read results.</returns>
+    public IObservable<Responce<ushort[]>> ObserveWords(string address, int points, TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null, TimeSpan? pollTimeout = null)
+        => BuildPollingTrigger(pollInterval)
+            .SelectAsyncSequential(_ => ReadWordsAsync(address, points, CancellationToken.None))
+            .Conflate(minimumUpdateSpacing ?? TimeSpan.FromMilliseconds(10), _scheduler)
+            .DoOnSubscribe(() => PublishOperation($"Observe words {address} subscribed", true, Array.Empty<byte>(), Array.Empty<byte>()))
+            .DoOnDispose(() => PublishOperation($"Observe words {address} disposed", true, Array.Empty<byte>(), Array.Empty<byte>()));
+
+    /// <summary>
+    /// Continuously polls a bit range and emits sequential results.
+    /// </summary>
+    /// <param name="address">Device address.</param>
+    /// <param name="points">Number of bits.</param>
+    /// <param name="pollInterval">Polling interval.</param>
+    /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
+    /// <returns>Observable bit results.</returns>
+    public IObservable<Responce<bool[]>> ObserveBits(string address, int points, TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)
+        => BuildPollingTrigger(pollInterval)
+            .SelectAsyncSequential(_ => ReadBitsAsync(address, points, CancellationToken.None))
+            .Conflate(minimumUpdateSpacing ?? TimeSpan.FromMilliseconds(10), _scheduler)
+            .DoOnSubscribe(() => PublishOperation($"Observe bits {address} subscribed", true, Array.Empty<byte>(), Array.Empty<byte>()))
+            .DoOnDispose(() => PublishOperation($"Observe bits {address} disposed", true, Array.Empty<byte>(), Array.Empty<byte>()));
+
+    /// <summary>
+    /// Polls a word range and injects heartbeat items when no new results arrive.
+    /// </summary>
+    /// <param name="address">Device address.</param>
+    /// <param name="points">Number of words.</param>
+    /// <param name="pollInterval">Polling interval.</param>
+    /// <param name="heartbeatAfter">Heartbeat interval.</param>
+    /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
+    /// <param name="pollTimeout">Per-poll timeout.</param>
+    /// <returns>Observable heartbeat stream.</returns>
+    public IObservable<IHeartbeat<Responce<ushort[]>>> ObserveWordsHeartbeat(string address, int points, TimeSpan pollInterval, TimeSpan heartbeatAfter, TimeSpan? minimumUpdateSpacing = null, TimeSpan? pollTimeout = null)
+        => ObserveWords(address, points, pollInterval, minimumUpdateSpacing, pollTimeout).Heartbeat(heartbeatAfter, _scheduler);
+
+    /// <summary>
+    /// Polls a word range and emits stale markers when the stream goes quiet.
+    /// </summary>
+    /// <param name="address">Device address.</param>
+    /// <param name="points">Number of words.</param>
+    /// <param name="pollInterval">Polling interval.</param>
+    /// <param name="staleAfter">Staleness threshold.</param>
+    /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
+    /// <returns>Observable stale-aware stream.</returns>
+    public IObservable<IStale<Responce<ushort[]>>> ObserveWordsStale(string address, int points, TimeSpan pollInterval, TimeSpan staleAfter, TimeSpan? minimumUpdateSpacing = null)
+        => ObserveWords(address, points, pollInterval, minimumUpdateSpacing).DetectStale(staleAfter, _scheduler);
+
+    /// <summary>
+    /// Polls a word range using an external trigger and emits only the latest completed read.
+    /// </summary>
+    /// <param name="address">Device address.</param>
+    /// <param name="points">Number of words.</param>
+    /// <param name="trigger">Trigger stream.</param>
+    /// <returns>Observable latest-result stream.</returns>
+    public IObservable<Responce<ushort[]>> ObserveWordsLatest(string address, int points, IObservable<Unit> trigger)
+    {
+        ArgumentNullException.ThrowIfNull(trigger);
+        return trigger.SelectLatestAsync(_ => ReadWordsAsync(address, points, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// Continuously polls a configured tag group and emits sequential grouped snapshots.
+    /// </summary>
+    /// <param name="groupName">Configured group name.</param>
+    /// <param name="pollInterval">Polling interval.</param>
+    /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
+    /// <returns>Observable grouped snapshots.</returns>
+    public IObservable<Responce<MitsubishiTagGroupSnapshot>> ObserveTagGroup(string groupName, TimeSpan pollInterval, TimeSpan? minimumUpdateSpacing = null)
+        => BuildPollingTrigger(pollInterval)
+            .SelectAsyncSequential(_ => ReadTagGroupSnapshotAsync(groupName, CancellationToken.None))
+            .Conflate(minimumUpdateSpacing ?? TimeSpan.FromMilliseconds(10), _scheduler)
+            .DoOnSubscribe(() => PublishOperation($"Observe tag group {groupName} subscribed", true, Array.Empty<byte>(), Array.Empty<byte>()))
+            .DoOnDispose(() => PublishOperation($"Observe tag group {groupName} disposed", true, Array.Empty<byte>(), Array.Empty<byte>()));
+
+    /// <summary>
+    /// Polls a configured tag group and injects heartbeat items when no new grouped snapshots arrive.
+    /// </summary>
+    /// <param name="groupName">Configured group name.</param>
+    /// <param name="pollInterval">Polling interval.</param>
+    /// <param name="heartbeatAfter">Heartbeat interval.</param>
+    /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
+    /// <returns>Observable heartbeat stream.</returns>
+    public IObservable<IHeartbeat<Responce<MitsubishiTagGroupSnapshot>>> ObserveTagGroupHeartbeat(string groupName, TimeSpan pollInterval, TimeSpan heartbeatAfter, TimeSpan? minimumUpdateSpacing = null)
+        => ObserveTagGroup(groupName, pollInterval, minimumUpdateSpacing).Heartbeat(heartbeatAfter, _scheduler);
+
+    /// <summary>
+    /// Polls a configured tag group and emits stale markers when the stream goes quiet.
+    /// </summary>
+    /// <param name="groupName">Configured group name.</param>
+    /// <param name="pollInterval">Polling interval.</param>
+    /// <param name="staleAfter">Staleness threshold.</param>
+    /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
+    /// <returns>Observable stale-aware stream.</returns>
+    public IObservable<IStale<Responce<MitsubishiTagGroupSnapshot>>> ObserveTagGroupStale(string groupName, TimeSpan pollInterval, TimeSpan staleAfter, TimeSpan? minimumUpdateSpacing = null)
+        => ObserveTagGroup(groupName, pollInterval, minimumUpdateSpacing).DetectStale(staleAfter, _scheduler);
+
+    /// <summary>
+    /// Polls a configured tag group using an external trigger and emits only the latest completed grouped snapshot.
+    /// </summary>
+    /// <param name="groupName">Configured group name.</param>
+    /// <param name="trigger">Trigger stream.</param>
+    /// <returns>Observable latest-result stream.</returns>
+    public IObservable<Responce<MitsubishiTagGroupSnapshot>> ObserveTagGroupLatest(string groupName, IObservable<Unit> trigger)
+    {
+        ArgumentNullException.ThrowIfNull(trigger);
+        return trigger.SelectLatestAsync(_ => ReadTagGroupSnapshotAsync(groupName, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// Samples the latest operation log whenever a trigger fires.
+    /// </summary>
+    /// <param name="trigger">Trigger stream.</param>
+    /// <returns>Sampled diagnostics stream.</returns>
+    public IObservable<MitsubishiOperationLog> SampleDiagnostics(IObservable<object> trigger)
+    {
+        ArgumentNullException.ThrowIfNull(trigger);
+        return OperationLogs.SampleLatest(trigger);
+    }
+
+    /// <summary>
+    /// Observes connection health using stale detection over state changes.
+    /// </summary>
+    /// <param name="staleAfter">Staleness threshold.</param>
+    /// <returns>Observable health states.</returns>
+    public IObservable<IStale<MitsubishiConnectionState>> ObserveConnectionHealth(TimeSpan staleAfter)
+        => ConnectionStates.DetectStale(staleAfter, _scheduler);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _connectionStates.OnCompleted();
+        _operationLogs.OnCompleted();
+        _connectionStates.Dispose();
+        _operationLogs.Dispose();
+        _transport.Dispose();
+        _requestGate.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _connectionStates.OnCompleted();
+        _operationLogs.OnCompleted();
+        _connectionStates.Dispose();
+        _operationLogs.Dispose();
+        await _transport.DisposeAsync().ConfigureAwait(false);
+        _requestGate.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static IPEndPoint BuildEndPoint(MitsubishiClientOptions options)
+    {
+        if (IPAddress.TryParse(options.Host, out var ipAddress))
+        {
+            return new IPEndPoint(ipAddress, options.Port);
+        }
+
+        return new IPEndPoint(IPAddress.Any, options.Port);
+    }
+
+    private static IMitsubishiTransport CreateDefaultTransport(MitsubishiClientOptions options)
+        => options.TransportKind == MitsubishiTransportKind.Serial
+            ? new ReactiveSerialMitsubishiTransport()
+            : new SocketMitsubishiTransport();
+
+    private static ushort[] ParseWordPayload(MitsubishiClientOptions options, byte[] payload, int? expectedWordCount = null)
+    {
+        if (options.DataCode == CommunicationDataCode.Binary)
+        {
+            var count = expectedWordCount ?? (payload.Length / 2);
+            var values = new ushort[count];
+            for (var index = 0; index < count; index++)
             {
-                _socket?.SafeClose();
-                return result;
+                values[index] = BitConverter.ToUInt16(payload, index * 2);
             }
-            catch (Exception ex)
+
+            return values;
+        }
+
+        var text = System.Text.Encoding.ASCII.GetString(payload);
+        var countFromAscii = expectedWordCount ?? (text.Length / 4);
+        var valuesFromAscii = new ushort[countFromAscii];
+        for (var index = 0; index < countFromAscii; index++)
+        {
+            valuesFromAscii[index] = Convert.ToUInt16(text.Substring(index * 4, 4), 16);
+        }
+
+        return valuesFromAscii;
+    }
+
+    private IObservable<long> BuildPollingTrigger(TimeSpan pollInterval)
+        => Observable.Interval(pollInterval, _scheduler).StartWith(0L);
+
+    private async Task<Responce> ExecuteControlAsync(ushort command, CancellationToken cancellationToken, bool force = true, bool clearMode = false)
+    {
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeRemoteOperation(Options, command, force, clearMode),
+            null,
+            $"Remote operation {command:X4}",
+            cancellationToken).ConfigureAwait(false);
+        return raw.ToBaseResponse();
+    }
+
+    private async Task<Responce> ExecutePasswordAsync(ushort command, string password, CancellationToken cancellationToken)
+    {
+        var raw = await ExecuteObservableAsync(
+            () => MitsubishiProtocolEncoding.EncodeRemotePassword(Options, command, password),
+            null,
+            command == MitsubishiCommands.Unlock ? "Unlock" : "Lock",
+            cancellationToken).ConfigureAwait(false);
+        return raw.ToBaseResponse();
+    }
+
+    private async Task<Responce<byte[]>> ExecuteEncodedAsync(byte[] command, int? expectedLength, string description, int maxRetries = 2, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        return await ExecuteObservableAsync(() => command, expectedLength, description, cancellationToken, maxRetries).ConfigureAwait(false);
+    }
+
+    private async Task<Responce<byte[]>> ExecuteObservableAsync(Func<byte[]> payloadFactory, int? expectedLength, string description, CancellationToken cancellationToken, int maxRetries = 2)
+    {
+        ArgumentNullException.ThrowIfNull(payloadFactory);
+        var observable = Observable.Defer(() => Observable.FromAsync(ct => ExecuteOnceAsync(payloadFactory, expectedLength, description, ct)))
+            .RetryWithBackoff(maxRetries, TimeSpan.FromMilliseconds(100), scheduler: _scheduler)
+            .Catch<Responce<byte[]>, Exception>(ex => Observable.Return(new Responce<byte[]>().Fail(ex.Message, exception: ex)));
+
+        return await observable.FirstAsync().ToTask(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Responce<byte[]>> ExecuteOnceAsync(Func<byte[]> payloadFactory, int? expectedLength, string description, CancellationToken cancellationToken)
+    {
+        ThrowIfDisposed();
+        await _requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false);
+            var payload = payloadFactory();
+            var request = new MitsubishiTransportRequest(payload, expectedLength, description);
+            var response = await _transport.ExchangeAsync(request, cancellationToken).ConfigureAwait(false);
+            var decoded = Options.TransportKind == MitsubishiTransportKind.Serial
+                ? MitsubishiSerialProtocolEncoding.Decode(Options, response)
+                : MitsubishiProtocolEncoding.Decode(Options, request, response);
+            decoded.Request = Convert.ToHexString(payload);
+            decoded.Response = Convert.ToHexString(response);
+            PublishOperation(description, decoded.IsSucceed, payload, response, decoded.Exception);
+            return decoded;
+        }
+        catch (Exception ex)
+        {
+            PublishFault(description, Array.Empty<byte>(), Array.Empty<byte>(), ex);
+            await _transport.DisconnectAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+        finally
+        {
+            _requestGate.Release();
+        }
+    }
+
+    private async Task EnsureConnectedAsync(CancellationToken cancellationToken)
+    {
+        if (_transport.IsConnected)
+        {
+            PublishState(MitsubishiConnectionState.Connected);
+            return;
+        }
+
+        PublishState(_connectionStates.Value == MitsubishiConnectionState.Disconnected ? MitsubishiConnectionState.Connecting : MitsubishiConnectionState.Reconnecting);
+        await _transport.ConnectAsync(Options, cancellationToken).ConfigureAwait(false);
+        PublishState(MitsubishiConnectionState.Connected);
+    }
+
+    private Responce<bool[]> ParseBits(Responce<byte[]> raw, int expectedBitCount)
+    {
+        if (!raw.IsSucceed || raw.Value is null)
+        {
+            return new Responce<bool[]>(raw);
+        }
+
+        try
+        {
+            var values = Options.DataCode == CommunicationDataCode.Binary
+                ? ParseBinaryBits(raw.Value, expectedBitCount)
+                : ParseAsciiBits(raw.Value, expectedBitCount);
+            return new Responce<bool[]>(raw, values);
+        }
+        catch (Exception ex)
+        {
+            return new Responce<bool[]>(raw).Fail(ex.Message, exception: ex);
+        }
+    }
+
+    private Responce<MitsubishiTypeName> ParseTypeName(Responce<byte[]> raw)
+    {
+        if (!raw.IsSucceed || raw.Value is null)
+        {
+            return new Responce<MitsubishiTypeName>(raw);
+        }
+
+        try
+        {
+            if (Options.DataCode == CommunicationDataCode.Binary)
             {
-                result.IsSucceed = false;
-                result.Err = ex.Message;
-                result.Exception = ex;
-                return result;
+                var code = raw.Value.Length >= 2 ? BitConverter.ToUInt16(raw.Value, raw.Value.Length - 2) : (ushort)0;
+                var nameLength = Math.Max(0, raw.Value.Length - 2);
+                var name = System.Text.Encoding.ASCII.GetString(raw.Value, 0, nameLength).TrimEnd('\0', ' ');
+                return new Responce<MitsubishiTypeName>(raw, new MitsubishiTypeName(name, code));
+            }
+
+            var ascii = System.Text.Encoding.ASCII.GetString(raw.Value).Trim();
+            var modelCode = ascii.Length >= 4 && ushort.TryParse(ascii[^4..], System.Globalization.NumberStyles.HexNumber, null, out var parsed)
+                ? parsed
+                : (ushort)0;
+            var modelName = ascii.Length > 4 ? ascii[..^4].Trim() : ascii;
+            return new Responce<MitsubishiTypeName>(raw, new MitsubishiTypeName(modelName, modelCode));
+        }
+        catch (Exception ex)
+        {
+            return new Responce<MitsubishiTypeName>(raw).Fail(ex.Message, exception: ex);
+        }
+    }
+
+    private Responce<ushort[]> ParseWords(Responce<byte[]> raw, int? expectedWordCount = null)
+    {
+        if (!raw.IsSucceed || raw.Value is null)
+        {
+            return new Responce<ushort[]>(raw);
+        }
+
+        try
+        {
+            return new Responce<ushort[]>(raw, ParseWordPayload(Options, raw.Value, expectedWordCount));
+        }
+        catch (Exception ex)
+        {
+            return new Responce<ushort[]>(raw).Fail(ex.Message, exception: ex);
+        }
+    }
+
+    private static bool[] ParseAsciiBits(byte[] payload, int expectedBitCount)
+    {
+        var text = System.Text.Encoding.ASCII.GetString(payload);
+        var bits = new List<bool>(expectedBitCount);
+        foreach (var ch in text)
+        {
+            if (ch is '0' or '1')
+            {
+                bits.Add(ch == '1');
+            }
+
+            if (bits.Count == expectedBitCount)
+            {
+                break;
             }
         }
+
+        return bits.ToArray();
+    }
+
+    private static bool[] ParseBinaryBits(byte[] payload, int expectedBitCount)
+    {
+        var bits = new List<bool>(expectedBitCount);
+        foreach (var value in payload)
+        {
+            bits.Add((value & 0x0F) != 0);
+            if (bits.Count == expectedBitCount)
+            {
+                break;
+            }
+
+            bits.Add((value & 0xF0) != 0);
+            if (bits.Count == expectedBitCount)
+            {
+                break;
+            }
+        }
+
+        return bits.ToArray();
+    }
+
+    private MitsubishiTagDefinition GetRequiredTag(string tagName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tagName);
+        var database = TagDatabase ?? throw new InvalidOperationException("TagDatabase must be assigned before tag-based APIs can be used.");
+        return database.GetRequired(tagName);
+    }
+
+    private static Responce<T> ConvertWords<T>(Responce<ushort[]> raw, Func<ushort[], T> converter)
+    {
+        ArgumentNullException.ThrowIfNull(converter);
+        if (!raw.IsSucceed || raw.Value is null)
+        {
+            return new Responce<T>(raw);
+        }
+
+        try
+        {
+            return new Responce<T>(raw, converter(raw.Value));
+        }
+        catch (Exception ex)
+        {
+            return new Responce<T>(raw).Fail(ex.Message, exception: ex);
+        }
+    }
+
+    private static double ReadNumericTagValue(MitsubishiTagDefinition tag, ushort[] words)
+        => tag.DataType switch
+        {
+            null or "Word" => tag.Signed ? unchecked((short)words[0]) : words[0],
+            "Int16" => unchecked((short)words[0]),
+            "UInt16" => words[0],
+            "DWord" => unchecked((uint)(words[0] | (words[1] << 16))),
+            "Int32" => ConvertToInt32(words, tag),
+            "UInt32" => ConvertToUInt32(words, tag),
+            "Float" => ConvertToFloat(words, tag),
+            _ => throw new InvalidOperationException($"Numeric conversion is not supported for DataType '{tag.DataType}'.")
+        };
+
+    private static int GetWordCountForScaledRead(MitsubishiTagDefinition tag)
+        => tag.DataType switch
+        {
+            null or "Word" or "Int16" or "UInt16" => 1,
+            "DWord" or "Int32" or "UInt32" or "Float" => 2,
+            _ => throw new InvalidOperationException($"Scaled access is not supported for DataType '{tag.DataType}'.")
+        };
+
+    private static double ApplyScaleAndOffset(double rawValue, MitsubishiTagDefinition tag)
+        => (rawValue * tag.Scale) + tag.Offset;
+
+    private static double RemoveScaleAndOffset(double engineeringValue, MitsubishiTagDefinition tag)
+    {
+        if (tag.Scale == 0)
+        {
+            throw new InvalidOperationException($"Tag '{tag.Name}' has Scale=0 and cannot be used for scaled writes.");
+        }
+
+        return (engineeringValue - tag.Offset) / tag.Scale;
+    }
+
+    private static uint ConvertToUInt32(ushort[] words, MitsubishiTagDefinition tag)
+    {
+        EnsureWordCount(words, 2, tag.Name);
+        return tag.ByteOrder == "BigEndian"
+            ? unchecked((uint)((words[0] << 16) | words[1]))
+            : unchecked((uint)(words[0] | (words[1] << 16)));
+    }
+
+    private static int ConvertToInt32(ushort[] words, MitsubishiTagDefinition tag)
+        => unchecked((int)ConvertToUInt32(words, tag));
+
+    private static float ConvertToFloat(ushort[] words, MitsubishiTagDefinition tag)
+        => BitConverter.Int32BitsToSingle(ConvertToInt32(words, tag));
+
+    private static ushort[] ConvertFromInt32(int value, MitsubishiTagDefinition tag)
+    {
+        var raw = unchecked((uint)value);
+        return tag.ByteOrder == "BigEndian"
+            ? [unchecked((ushort)(raw >> 16)), unchecked((ushort)(raw & 0xFFFF))]
+            : [unchecked((ushort)(raw & 0xFFFF)), unchecked((ushort)(raw >> 16))];
+    }
+
+    private static ushort[] ConvertFromUInt32(uint value, MitsubishiTagDefinition tag)
+        => tag.ByteOrder == "BigEndian"
+            ? [unchecked((ushort)(value >> 16)), unchecked((ushort)(value & 0xFFFF))]
+            : [unchecked((ushort)(value & 0xFFFF)), unchecked((ushort)(value >> 16))];
+
+    private static ushort[] ConvertFromFloat(float value, MitsubishiTagDefinition tag)
+        => ConvertFromInt32(BitConverter.SingleToInt32Bits(value), tag);
+
+    private static void EnsureWordCount(ushort[] words, int requiredCount, string tagName)
+    {
+        if (words.Length < requiredCount)
+        {
+            throw new InvalidOperationException($"Tag '{tagName}' requires at least {requiredCount} word(s), but only {words.Length} were read.");
+        }
+    }
+
+    private static string DecodeStringFromWords(ushort[] words, MitsubishiTagDefinition tag)
+    {
+        var bytes = new byte[words.Length * 2];
+        for (var index = 0; index < words.Length; index++)
+        {
+            var span = bytes.AsSpan(index * 2, 2);
+            if (tag.ByteOrder == "BigEndian")
+            {
+                BinaryPrimitives.WriteUInt16BigEndian(span, words[index]);
+            }
+            else
+            {
+                BinaryPrimitives.WriteUInt16LittleEndian(span, words[index]);
+            }
+        }
+
+        return GetTextEncoding(tag).GetString(bytes).TrimEnd('\0');
+    }
+
+    private static ushort[] EncodeStringWords(string value, int wordLength, MitsubishiTagDefinition tag)
+    {
+        var bytes = GetTextEncoding(tag).GetBytes(value);
+        var maxBytes = checked(wordLength * 2);
+        if (bytes.Length > maxBytes)
+        {
+            throw new ArgumentException($"String length {bytes.Length} exceeds the requested PLC word capacity of {maxBytes} bytes.", nameof(value));
+        }
+
+        var padded = new byte[maxBytes];
+        bytes.CopyTo(padded, 0);
+        var words = new ushort[wordLength];
+        for (var index = 0; index < wordLength; index++)
+        {
+            var span = padded.AsSpan(index * 2, 2);
+            words[index] = tag.ByteOrder == "BigEndian"
+                ? BinaryPrimitives.ReadUInt16BigEndian(span)
+                : BinaryPrimitives.ReadUInt16LittleEndian(span);
+        }
+
+        return words;
+    }
+
+    private static Encoding GetTextEncoding(MitsubishiTagDefinition tag)
+        => tag.Encoding switch
+        {
+            "Utf8" => Encoding.UTF8,
+            "Utf16" => Encoding.Unicode,
+            _ => Encoding.ASCII,
+        };
+
+    private MitsubishiTagDatabase GetRequiredTagDatabase()
+        => TagDatabase ?? throw new InvalidOperationException("TagDatabase must be assigned before tag-based APIs can be used.");
+
+    private async Task<Responce<object?>> ReadTagValueAsync(string tagName, CancellationToken cancellationToken)
+    {
+        var tag = GetRequiredTag(tagName);
+
+        return tag.DataType switch
+        {
+            "Bit" => await ConvertTagValueAsync(ReadBitsByTagAsync(tagName, 1, cancellationToken), static values => values[0]).ConfigureAwait(false),
+            "String" => await ConvertTagValueAsync(ReadStringByTagAsync(tagName, cancellationToken), static value => value).ConfigureAwait(false),
+            "Float" => await ConvertTagValueAsync(ReadFloatByTagAsync(tagName, cancellationToken), static value => (object?)value).ConfigureAwait(false),
+            "DWord" or "UInt32" => await ConvertTagValueAsync(ReadDWordByTagAsync(tagName, cancellationToken), static value => (object?)value).ConfigureAwait(false),
+            "Int32" => await ConvertTagValueAsync(ReadInt32ByTagAsync(tagName, cancellationToken), static value => (object?)value).ConfigureAwait(false),
+            "Int16" => await ConvertTagValueAsync(ReadInt16ByTagAsync(tagName, cancellationToken), static value => (object?)value).ConfigureAwait(false),
+            "UInt16" => await ConvertTagValueAsync(ReadUInt16ByTagAsync(tagName, cancellationToken), static value => (object?)value).ConfigureAwait(false),
+            _ when HasEngineeringMetadata(tag) => await ConvertTagValueAsync(ReadScaledDoubleByTagAsync(tagName, cancellationToken), static value => (object?)value).ConfigureAwait(false),
+            _ => await ConvertTagValueAsync(ReadWordsByTagAsync(tagName, 1, cancellationToken), static values => (object?)values[0]).ConfigureAwait(false),
+        };
+    }
+
+    private async Task<Responce> WriteTagValueAsync(string tagName, object? value, CancellationToken cancellationToken)
+    {
+        var tag = GetRequiredTag(tagName);
+        try
+        {
+            switch (tag.DataType)
+            {
+                case "Bit":
+                    if (value is bool bit)
+                    {
+                        return await WriteBitsByTagAsync(tagName, [bit], cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+                case "String":
+                    if (value is string text)
+                    {
+                        return await WriteStringByTagAsync(tagName, text, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+                case "Float":
+                    if (value is float single)
+                    {
+                        return await WriteFloatByTagAsync(tagName, single, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+                case "DWord":
+                case "UInt32":
+                    if (value is uint uint32)
+                    {
+                        return await WriteDWordByTagAsync(tagName, uint32, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+                case "Int32":
+                    if (value is int int32)
+                    {
+                        return await WriteInt32ByTagAsync(tagName, int32, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+                case "Int16":
+                    if (value is short int16)
+                    {
+                        return await WriteInt16ByTagAsync(tagName, int16, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+                case "UInt16":
+                    if (value is ushort uint16)
+                    {
+                        return await WriteUInt16ByTagAsync(tagName, uint16, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+                default:
+                    if (HasEngineeringMetadata(tag) && value is double engineering)
+                    {
+                        return await WriteScaledDoubleByTagAsync(tagName, engineering, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    if (value is ushort rawWord)
+                    {
+                        return await WriteWordsByTagAsync(tagName, [rawWord], cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            return new Responce().Fail(ex.Message, exception: ex);
+        }
+
+        return new Responce().Fail($"Value for tag '{tagName}' is not compatible with DataType '{tag.DataType ?? "Word"}'.");
+    }
+
+    private static bool CanWriteTagValue(MitsubishiTagDefinition tag, object? value, out string? error)
+    {
+        if (value is null)
+        {
+            error = $"Tag '{tag.Name}' cannot be written with a null value.";
+            return false;
+        }
+
+        var ok = tag.DataType switch
+        {
+            "Bit" => value is bool,
+            "String" => value is string,
+            "Float" => value is float,
+            "DWord" or "UInt32" => value is uint,
+            "Int32" => value is int,
+            "Int16" => value is short,
+            "UInt16" => value is ushort,
+            _ when HasEngineeringMetadata(tag) => value is double,
+            _ => value is ushort,
+        };
+
+        error = ok ? null : $"Tag '{tag.Name}' expects a value compatible with DataType '{tag.DataType ?? "Word"}', but received '{value.GetType().Name}'.";
+        return ok;
+    }
+
+    private static async Task<Responce<object?>> ConvertTagValueAsync<T>(Task<Responce<T>> task, Func<T, object?> projector)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        ArgumentNullException.ThrowIfNull(projector);
+        var raw = await task.ConfigureAwait(false);
+        if (!raw.IsSucceed || raw.Value is null)
+        {
+            return new Responce<object?>(raw);
+        }
+
+        return new Responce<object?>(raw, projector(raw.Value));
+    }
+
+    private static bool HasEngineeringMetadata(MitsubishiTagDefinition tag)
+        => Math.Abs(tag.Scale - 1.0) > double.Epsilon || Math.Abs(tag.Offset) > double.Epsilon;
+
+    private static Responce ValidateRolloutPolicy(MitsubishiTagDatabaseDiff diff, MitsubishiTagRolloutPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+
+        if (policy == MitsubishiTagRolloutPolicy.AllowAll)
+        {
+            return new Responce().EndTime();
+        }
+
+        if (policy == MitsubishiTagRolloutPolicy.SafeMetadataAndGroups)
+        {
+            var disallowed = diff.ChangeKinds & (MitsubishiSchemaChangeKind.AddressChange | MitsubishiSchemaChangeKind.DataTypeChange | MitsubishiSchemaChangeKind.StructureChange);
+            if (disallowed == MitsubishiSchemaChangeKind.None)
+            {
+                return new Responce().EndTime();
+            }
+
+            return new Responce().Fail($"Rollout policy '{policy}' rejected schema changes: {disallowed}.");
+        }
+
+        return new Responce().Fail($"Unsupported rollout policy '{policy}'.");
+    }
+
+    private static string GetSchemaFingerprint(string path)
+    {
+        var info = new FileInfo(path);
+        if (!info.Exists)
+        {
+            return $"{info.FullName}|missing";
+        }
+
+        var content = File.ReadAllBytes(path);
+        var hash = Convert.ToHexString(SHA256.HashData(content));
+        return $"{info.FullName}|{content.Length}|{hash}";
+    }
+
+    private string ResolveTagAddress(string tagName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tagName);
+        var database = TagDatabase ?? throw new InvalidOperationException("TagDatabase must be assigned before tag-based APIs can be used.");
+        return database.GetRequired(tagName).Address;
+    }
+
+    private IReadOnlyList<string> ResolveTagAddresses(IEnumerable<string> tagNames)
+    {
+        ArgumentNullException.ThrowIfNull(tagNames);
+        return tagNames.Select(ResolveTagAddress).ToArray();
+    }
+
+    private void PublishFault(string description, ReadOnlyMemory<byte> request, ReadOnlyMemory<byte> response, Exception exception)
+    {
+        PublishState(MitsubishiConnectionState.Faulted);
+        PublishOperation(description, false, request, response, exception);
+    }
+
+    private void PublishOperation(string description, bool success, ReadOnlyMemory<byte> request, ReadOnlyMemory<byte> response, Exception? exception = null)
+    {
+        _operationLogs.OnNext(new MitsubishiOperationLog(
+            DateTimeOffset.UtcNow,
+            _connectionStates.Value,
+            description,
+            success,
+            request,
+            response,
+            exception));
+    }
+
+    private void PublishState(MitsubishiConnectionState state)
+    {
+        if (_connectionStates.Value != state)
+        {
+            _connectionStates.OnNext(state);
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 }

--- a/src/MitsubishiRx/MitsubishiRx.csproj
+++ b/src/MitsubishiRx/MitsubishiRx.csproj
@@ -1,13 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ReactiveUI.Extensions" Version="2.3.1" />
+    <PackageReference Include="SerialPortRx" Version="3.4.4" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
-
 </Project>

--- a/src/MitsubishiRx/MitsubishiSerial.cs
+++ b/src/MitsubishiRx/MitsubishiSerial.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Ports;
+
+namespace MitsubishiRx;
+
+/// <summary>
+/// Defines the serial MC protocol message formats supported by the library.
+/// </summary>
+public enum MitsubishiSerialMessageFormat
+{
+    /// <summary>
+    /// Format 1: ASCII with ENQ/STX/ACK/NAK framing.
+    /// </summary>
+    Format1,
+
+    /// <summary>
+    /// Format 4: ASCII with CR/LF framing.
+    /// </summary>
+    Format4,
+
+    /// <summary>
+    /// Format 5: Binary 4C frame with DLE/STX/ETX framing.
+    /// </summary>
+    Format5,
+}
+
+/// <summary>
+/// Reactive serial-port settings for Mitsubishi serial MC protocol communication.
+/// </summary>
+/// <param name="PortName">Serial port name, for example COM3.</param>
+/// <param name="BaudRate">Configured baud rate.</param>
+/// <param name="DataBits">Configured data bits.</param>
+/// <param name="Parity">Configured parity.</param>
+/// <param name="StopBits">Configured stop bits.</param>
+/// <param name="Handshake">Configured handshake.</param>
+/// <param name="MessageFormat">Configured serial message format.</param>
+/// <param name="StationNumber">Target station number.</param>
+/// <param name="NetworkNumber">Target network number for 3C/4C routes.</param>
+/// <param name="PcNumber">Target PC number.</param>
+/// <param name="RequestDestinationModuleIoNumber">Request destination module I/O number for 4C format 5.</param>
+/// <param name="RequestDestinationModuleStationNumber">Request destination module station number for 4C format 5.</param>
+/// <param name="SelfStationNumber">Self-station number for multidrop topologies.</param>
+/// <param name="MessageWait">Message wait in 10 ms units.</param>
+/// <param name="ReadBufferSize">Serial read buffer size.</param>
+/// <param name="WriteBufferSize">Serial write buffer size.</param>
+/// <param name="NewLine">Configured newline sequence for line-oriented modes.</param>
+public sealed record MitsubishiSerialOptions(
+    string PortName,
+    int BaudRate = 9600,
+    int DataBits = 7,
+    Parity Parity = Parity.Even,
+    StopBits StopBits = StopBits.One,
+    Handshake Handshake = Handshake.None,
+    MitsubishiSerialMessageFormat MessageFormat = MitsubishiSerialMessageFormat.Format5,
+    byte StationNumber = 0x00,
+    byte NetworkNumber = 0x00,
+    byte PcNumber = 0xFF,
+    ushort RequestDestinationModuleIoNumber = 0x03FF,
+    byte RequestDestinationModuleStationNumber = 0x00,
+    byte SelfStationNumber = 0x00,
+    byte MessageWait = 0x00,
+    int ReadBufferSize = 4096,
+    int WriteBufferSize = 4096,
+    string NewLine = "\r\n")
+{
+    /// <summary>
+    /// Gets the default direct-connect serial route.
+    /// </summary>
+    public MitsubishiSerialRoute Route => new(
+        StationNumber,
+        NetworkNumber,
+        PcNumber,
+        RequestDestinationModuleIoNumber,
+        RequestDestinationModuleStationNumber,
+        SelfStationNumber);
+}
+
+/// <summary>
+/// Serial route metadata used by 1C/3C/4C message builders.
+/// </summary>
+/// <param name="StationNumber">Target station number.</param>
+/// <param name="NetworkNumber">Target network number.</param>
+/// <param name="PcNumber">Target PC number.</param>
+/// <param name="RequestDestinationModuleIoNumber">Request destination module I/O number.</param>
+/// <param name="RequestDestinationModuleStationNumber">Request destination module station number.</param>
+/// <param name="SelfStationNumber">Self-station number.</param>
+public sealed record MitsubishiSerialRoute(
+    byte StationNumber,
+    byte NetworkNumber,
+    byte PcNumber,
+    ushort RequestDestinationModuleIoNumber,
+    byte RequestDestinationModuleStationNumber,
+    byte SelfStationNumber);

--- a/src/MitsubishiRx/MitsubishiSerialProtocolEncoding.cs
+++ b/src/MitsubishiRx/MitsubishiSerialProtocolEncoding.cs
@@ -1,0 +1,390 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Text;
+
+namespace MitsubishiRx;
+
+internal static class MitsubishiSerialProtocolEncoding
+{
+    private const byte Enq = 0x05;
+    private const byte Ack = 0x06;
+    private const byte Nak = 0x15;
+    private const byte Stx = 0x02;
+    private const byte Etx = 0x03;
+    private const byte Cr = 0x0D;
+    private const byte Lf = 0x0A;
+    private const byte Dle = 0x10;
+    private const byte FourCFrameId = 0xF8;
+    private const byte ThreeCFrameId = 0xF9;
+    private const string ResponseIdAscii = "FFFF";
+    private const ushort ResponseIdBinary = 0xFFFF;
+
+    public static byte[] EncodeWordReadRequest(MitsubishiClientOptions options, MitsubishiDeviceAddress address, int points)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(address);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(points);
+
+        return options.FrameType switch
+        {
+            MitsubishiFrameType.OneC => Encode1CRequest(options, address, points, wordUnits: true),
+            MitsubishiFrameType.ThreeC => Encode3CRequest(options, address, points, wordUnits: true),
+            MitsubishiFrameType.FourC => Encode4CRequest(options, address, points, wordUnits: true),
+            _ => throw new NotSupportedException($"Serial encoding is not supported for frame type '{options.FrameType}'."),
+        };
+    }
+
+    public static Responce<byte[]> Decode(MitsubishiClientOptions options, byte[] response)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(response);
+
+        return options.FrameType switch
+        {
+            MitsubishiFrameType.OneC => Decode1C(options, response),
+            MitsubishiFrameType.ThreeC => Decode3C(options, response),
+            MitsubishiFrameType.FourC => Decode4C(options, response),
+            _ => throw new NotSupportedException($"Serial decoding is not supported for frame type '{options.FrameType}'."),
+        };
+    }
+
+    public static bool IsExpectedFrameComplete(MitsubishiClientOptions options, ReadOnlySpan<byte> buffer)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (buffer.IsEmpty)
+        {
+            return false;
+        }
+
+        return options.FrameType switch
+        {
+            MitsubishiFrameType.OneC => options.ResolvedSerial.MessageFormat switch
+            {
+                MitsubishiSerialMessageFormat.Format1 => HasAsciiChecksumFramedMessage(buffer),
+                MitsubishiSerialMessageFormat.Format4 => HasAsciiChecksumFramedMessage(buffer),
+                _ => false,
+            },
+            MitsubishiFrameType.ThreeC => options.ResolvedSerial.MessageFormat switch
+            {
+                MitsubishiSerialMessageFormat.Format1 => HasAsciiChecksumFramedMessage(buffer),
+                MitsubishiSerialMessageFormat.Format4 => HasAsciiChecksumFramedMessage(buffer),
+                _ => false,
+            },
+            MitsubishiFrameType.FourC => options.ResolvedSerial.MessageFormat switch
+            {
+                MitsubishiSerialMessageFormat.Format1 => HasAsciiChecksumFramedMessage(buffer),
+                MitsubishiSerialMessageFormat.Format4 => HasAsciiChecksumFramedMessage(buffer),
+                MitsubishiSerialMessageFormat.Format5 => HasBinaryFormat5Message(buffer),
+                _ => false,
+            },
+            _ => false,
+        };
+    }
+
+    private static byte[] Encode1CRequest(MitsubishiClientOptions options, MitsubishiDeviceAddress address, int points, bool wordUnits)
+    {
+        EnsureAscii(options);
+        var serial = options.ResolvedSerial;
+        var metadata = address.Descriptor;
+        var command = wordUnits && metadata.Kind == DeviceValueKind.Word ? "WR" : "BR";
+        var body = string.Concat(
+            FormatAsciiByte(serial.StationNumber),
+            FormatAsciiByte(serial.PcNumber),
+            command,
+            FormatAsciiNibble(serial.MessageWait),
+            Format1CAddress(address, metadata),
+            FormatPointCount(points));
+
+        return WrapAscii(body, serial.MessageFormat);
+    }
+
+    private static byte[] Encode3CRequest(MitsubishiClientOptions options, MitsubishiDeviceAddress address, int points, bool wordUnits)
+    {
+        EnsureAscii(options);
+        var serial = options.ResolvedSerial;
+        var metadata = address.Descriptor;
+        var command = wordUnits && metadata.Kind == DeviceValueKind.Word ? "0401" : "0401";
+        var subcommand = wordUnits ? "0000" : "0001";
+        var body = string.Concat(
+            FormatAsciiByte(ThreeCFrameId),
+            FormatAsciiByte(serial.StationNumber),
+            FormatAsciiByte(serial.NetworkNumber),
+            FormatAsciiByte(serial.PcNumber),
+            FormatAsciiByte(serial.SelfStationNumber),
+            command,
+            subcommand,
+            FormatDeviceAddressModern(address, metadata),
+            FormatPointCount(points));
+
+        return WrapAscii(body, serial.MessageFormat);
+    }
+
+    private static byte[] Encode4CRequest(MitsubishiClientOptions options, MitsubishiDeviceAddress address, int points, bool wordUnits)
+    {
+        var serial = options.ResolvedSerial;
+        var metadata = address.Descriptor;
+        return serial.MessageFormat switch
+        {
+            MitsubishiSerialMessageFormat.Format1 or MitsubishiSerialMessageFormat.Format4 => Encode4CAsciiRequest(serial, address, metadata, points, wordUnits),
+            MitsubishiSerialMessageFormat.Format5 => Encode4CBinaryRequest(serial, address, metadata, points, wordUnits),
+            _ => throw new NotSupportedException($"Unsupported 4C serial message format '{serial.MessageFormat}'."),
+        };
+    }
+
+    private static byte[] Encode4CAsciiRequest(MitsubishiSerialOptions serial, MitsubishiDeviceAddress address, MitsubishiDeviceMetadata metadata, int points, bool wordUnits)
+    {
+        var command = wordUnits && metadata.Kind == DeviceValueKind.Word ? "0401" : "0401";
+        var subcommand = wordUnits ? "0000" : "0001";
+        var body = string.Concat(
+            FormatAsciiByte(FourCFrameId),
+            FormatAsciiByte(serial.StationNumber),
+            FormatAsciiByte(serial.NetworkNumber),
+            FormatAsciiByte(serial.PcNumber),
+            FormatAsciiUInt16(serial.RequestDestinationModuleIoNumber),
+            FormatAsciiByte(serial.RequestDestinationModuleStationNumber),
+            FormatAsciiByte(serial.SelfStationNumber),
+            command,
+            subcommand,
+            FormatDeviceAddressModern(address, metadata),
+            FormatPointCount(points));
+
+        return WrapAscii(body, serial.MessageFormat);
+    }
+
+    private static byte[] Encode4CBinaryRequest(MitsubishiSerialOptions serial, MitsubishiDeviceAddress address, MitsubishiDeviceMetadata metadata, int points, bool wordUnits)
+    {
+        var buffer = new List<byte>
+        {
+            FourCFrameId,
+            serial.StationNumber,
+            serial.NetworkNumber,
+            serial.PcNumber,
+            (byte)(serial.RequestDestinationModuleIoNumber & 0xFF),
+            (byte)(serial.RequestDestinationModuleIoNumber >> 8),
+            serial.RequestDestinationModuleStationNumber,
+            serial.SelfStationNumber,
+        };
+
+        AppendUInt16LittleEndian(buffer, 0x0401);
+        AppendUInt16LittleEndian(buffer, wordUnits ? (ushort)0x0000 : (ushort)0x0001);
+        AppendThreeByteLittleEndian(buffer, address.Number);
+        buffer.Add((byte)metadata.BinaryCode);
+        AppendUInt16LittleEndian(buffer, checked((ushort)points));
+        buffer.Add(Dle);
+        buffer.Add(Etx);
+
+        var numberOfDataBytes = checked((ushort)(buffer.Count - 3));
+        var prefix = new List<byte> { Dle, Stx };
+        AppendUInt16LittleEndian(prefix, numberOfDataBytes);
+        prefix.AddRange(buffer);
+        var checksum = ComputeChecksum(prefix.Skip(2));
+        prefix.AddRange(Encoding.ASCII.GetBytes(checksum));
+        return prefix.ToArray();
+    }
+
+    private static Responce<byte[]> Decode1C(MitsubishiClientOptions options, byte[] response)
+    {
+        var serial = options.ResolvedSerial;
+        var text = ExtractAsciiPayload(serial.MessageFormat, response);
+        var result = new Responce<byte[]> { Response = text };
+
+        if (text.Length < 4)
+        {
+            return result.Fail("1C serial response too short.");
+        }
+
+        if (text[0] == (char)Nak)
+        {
+            var errorCode = text.Length >= 6 ? Convert.ToInt32(text.Substring(4, 2), 16) : 0;
+            return result.Fail($"PLC returned 1C serial error 0x{errorCode:X2}.", errorCode);
+        }
+
+        var payloadStart = text[0] == (char)Ack ? 3 : 4;
+        result.Value = Encoding.ASCII.GetBytes(text[payloadStart..]);
+        return result.EndTime();
+    }
+
+    private static Responce<byte[]> Decode3C(MitsubishiClientOptions options, byte[] response)
+    {
+        var serial = options.ResolvedSerial;
+        var text = ExtractAsciiPayload(serial.MessageFormat, response);
+        var result = new Responce<byte[]> { Response = text };
+
+        if (text.Length < 6)
+        {
+            return result.Fail("3C serial response too short.");
+        }
+
+        if (text[0] == (char)Nak)
+        {
+            var errorCode = text.Length >= 8 ? Convert.ToInt32(text.Substring(6, 2), 16) : 0;
+            return result.Fail($"PLC returned 3C serial error 0x{errorCode:X2}.", errorCode);
+        }
+
+        var payloadStart = text[0] == (char)Ack ? 5 : 6;
+        result.Value = Encoding.ASCII.GetBytes(text[payloadStart..]);
+        return result.EndTime();
+    }
+
+    private static Responce<byte[]> Decode4C(MitsubishiClientOptions options, byte[] response)
+    {
+        var serial = options.ResolvedSerial;
+        return serial.MessageFormat == MitsubishiSerialMessageFormat.Format5
+            ? Decode4CBinary(response)
+            : Decode4CAscii(serial.MessageFormat, response);
+    }
+
+    private static Responce<byte[]> Decode4CAscii(MitsubishiSerialMessageFormat messageFormat, byte[] response)
+    {
+        var text = ExtractAsciiPayload(messageFormat, response);
+        var result = new Responce<byte[]> { Response = text };
+
+        if (text.Length < 12)
+        {
+            return result.Fail("4C serial ASCII response too short.");
+        }
+
+        if (text[0] == (char)Nak)
+        {
+            var errorCode = text.Length >= 14 ? Convert.ToInt32(text.Substring(12, 2), 16) : 0;
+            return result.Fail($"PLC returned 4C serial ASCII error 0x{errorCode:X2}.", errorCode);
+        }
+
+        var payloadStart = text[0] == (char)Ack ? 11 : 12;
+        result.Value = Encoding.ASCII.GetBytes(text[payloadStart..]);
+        return result.EndTime();
+    }
+
+    private static Responce<byte[]> Decode4CBinary(byte[] response)
+    {
+        var result = new Responce<byte[]> { Response = Convert.ToHexString(response) };
+        if (!HasBinaryFormat5Message(response))
+        {
+            return result.Fail("4C serial binary response is incomplete.");
+        }
+
+        if (response.Length < 17)
+        {
+            return result.Fail("4C serial binary response too short.");
+        }
+
+        var payloadStart = 14;
+        var responseId = BitConverter.ToUInt16(response, 12);
+        if (responseId != ResponseIdBinary)
+        {
+            return result.Fail("4C serial binary response has an invalid response identifier.");
+        }
+
+        var endCode = BitConverter.ToUInt16(response, payloadStart);
+        if (endCode != 0)
+        {
+            return result.Fail($"PLC returned 4C serial binary error 0x{endCode:X4}.", endCode);
+        }
+
+        var dataStart = payloadStart + 2;
+        var dataLength = response.Length - dataStart - 4;
+        result.Value = dataLength <= 0 ? Array.Empty<byte>() : response[dataStart..(dataStart + dataLength)];
+        return result.EndTime();
+    }
+
+    private static void EnsureAscii(MitsubishiClientOptions options)
+    {
+        if (options.DataCode != CommunicationDataCode.Ascii)
+        {
+            throw new NotSupportedException("1C and 3C serial communication require ASCII data encoding.");
+        }
+    }
+
+    private static string Format1CAddress(MitsubishiDeviceAddress address, MitsubishiDeviceMetadata metadata)
+    {
+        var digits = metadata.Symbol.Length > 1 ? 3 : 4;
+        return metadata.Symbol + address.Number.ToString($"D{digits}", CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatDeviceAddressModern(MitsubishiDeviceAddress address, MitsubishiDeviceMetadata metadata)
+        => address.Number.ToString("X6", CultureInfo.InvariantCulture) + metadata.Symbol.PadRight(2, '*');
+
+    private static string FormatPointCount(int points)
+        => (points == 256 ? 0 : points).ToString("X2", CultureInfo.InvariantCulture);
+
+    private static string FormatAsciiByte(byte value) => value.ToString("X2", CultureInfo.InvariantCulture);
+
+    private static string FormatAsciiNibble(byte value) => (value & 0x0F).ToString("X1", CultureInfo.InvariantCulture);
+
+    private static string FormatAsciiUInt16(ushort value) => value.ToString("X4", CultureInfo.InvariantCulture);
+
+    private static byte[] WrapAscii(string body, MitsubishiSerialMessageFormat format)
+    {
+        var checksum = Encoding.ASCII.GetBytes(ComputeChecksum(Encoding.ASCII.GetBytes(body)));
+        return format switch
+        {
+            MitsubishiSerialMessageFormat.Format1 => [Enq, .. Encoding.ASCII.GetBytes(body), .. checksum],
+            MitsubishiSerialMessageFormat.Format4 => [Cr, Lf, Enq, .. Encoding.ASCII.GetBytes(body), .. checksum, Cr, Lf],
+            _ => throw new NotSupportedException($"ASCII wrapping is not supported for serial format '{format}'."),
+        };
+    }
+
+    private static string ExtractAsciiPayload(MitsubishiSerialMessageFormat format, byte[] response)
+    {
+        var trimmed = format == MitsubishiSerialMessageFormat.Format4
+            ? response.Where(static value => value is not Cr and not Lf).ToArray()
+            : response;
+
+        if (trimmed.Length < 3)
+        {
+            return string.Empty;
+        }
+
+        var withoutChecksum = trimmed[..^2];
+        return Encoding.ASCII.GetString(withoutChecksum);
+    }
+
+    private static bool HasAsciiChecksumFramedMessage(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.Length < 5)
+        {
+            return false;
+        }
+
+        if (buffer[0] == Cr)
+        {
+            var trimmed = buffer.ToArray().Where(static value => value is not Cr and not Lf).ToArray();
+            return trimmed.Length >= 5 && (trimmed[0] == Enq || trimmed[0] == Stx || trimmed[0] == Ack || trimmed[0] == Nak);
+        }
+
+        return buffer[0] == Enq || buffer[0] == Stx || buffer[0] == Ack || buffer[0] == Nak;
+    }
+
+    private static bool HasBinaryFormat5Message(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.Length < 8 || buffer[0] != Dle || buffer[1] != Stx)
+        {
+            return false;
+        }
+
+        var byteCount = buffer[2] | (buffer[3] << 8);
+        var expectedLength = 4 + byteCount + 2 + 2;
+        return buffer.Length >= expectedLength;
+    }
+
+    private static string ComputeChecksum(IEnumerable<byte> bytes)
+    {
+        var sum = bytes.Aggregate(0, static (current, value) => current + value);
+        return (sum & 0xFF).ToString("X2", CultureInfo.InvariantCulture);
+    }
+
+    private static void AppendUInt16LittleEndian(List<byte> buffer, ushort value)
+    {
+        buffer.Add((byte)(value & 0xFF));
+        buffer.Add((byte)(value >> 8));
+    }
+
+    private static void AppendThreeByteLittleEndian(List<byte> buffer, int value)
+    {
+        buffer.Add((byte)(value & 0xFF));
+        buffer.Add((byte)((value >> 8) & 0xFF));
+        buffer.Add((byte)((value >> 16) & 0xFF));
+    }
+}

--- a/src/MitsubishiRx/MitsubishiTagDatabase.cs
+++ b/src/MitsubishiRx/MitsubishiTagDatabase.cs
@@ -1,0 +1,581 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Text;
+
+namespace MitsubishiRx;
+
+/// <summary>
+/// Named tag metadata that maps a human-friendly tag to a Mitsubishi device address.
+/// </summary>
+/// <param name="Name">Unique tag name.</param>
+/// <param name="Address">Raw Mitsubishi device address such as D100 or M10.</param>
+/// <param name="DataType">Optional data type hint such as Bit, Word, DWord, Float, or String.</param>
+/// <param name="Description">Optional operator-facing description.</param>
+/// <param name="Scale">Optional engineering scale factor.</param>
+/// <param name="Offset">Optional engineering offset.</param>
+/// <param name="Length">Optional logical length for string/array-like tags, expressed in PLC words.</param>
+/// <param name="Encoding">Optional string/text encoding hint such as Ascii or Utf8.</param>
+/// <param name="Units">Optional engineering units label for documentation/UI use.</param>
+/// <param name="Signed">Optional signedness hint for integer word and double-word values.</param>
+/// <param name="ByteOrder">Optional byte/word ordering hint such as LittleEndian or BigEndian.</param>
+/// <param name="Notes">Optional free-form notes.</param>
+public sealed record MitsubishiTagDefinition(
+    string Name,
+    string Address,
+    string? DataType = null,
+    string? Description = null,
+    double Scale = 1.0,
+    double Offset = 0.0,
+    int? Length = null,
+    string? Encoding = null,
+    string? Units = null,
+    bool Signed = false,
+    string? ByteOrder = null,
+    string? Notes = null);
+
+/// <summary>
+/// In-memory tag database used to resolve symbolic tag names into Mitsubishi PLC addresses.
+/// </summary>
+public sealed class MitsubishiTagDatabase
+{
+    private static readonly IReadOnlyDictionary<string, string> SupportedDataTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Bit"] = "Bit",
+        ["Word"] = "Word",
+        ["DWord"] = "DWord",
+        ["Float"] = "Float",
+        ["String"] = "String",
+        ["Int16"] = "Int16",
+        ["UInt16"] = "UInt16",
+        ["Int32"] = "Int32",
+        ["UInt32"] = "UInt32",
+    };
+
+    private static readonly IReadOnlyDictionary<string, string> SupportedEncodings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Ascii"] = "Ascii",
+        ["Utf8"] = "Utf8",
+        ["Utf16"] = "Utf16",
+    };
+
+    private static readonly IReadOnlyDictionary<string, string> SupportedByteOrders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["LittleEndian"] = "LittleEndian",
+        ["BigEndian"] = "BigEndian",
+    };
+
+    private readonly Dictionary<string, MitsubishiTagDefinition> _tags;
+    private readonly Dictionary<string, MitsubishiTagGroupDefinition> _groups;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MitsubishiTagDatabase"/> class.
+    /// </summary>
+    /// <param name="tags">Initial tag definitions.</param>
+    public MitsubishiTagDatabase(IEnumerable<MitsubishiTagDefinition> tags)
+    {
+        ArgumentNullException.ThrowIfNull(tags);
+        _tags = new Dictionary<string, MitsubishiTagDefinition>(StringComparer.OrdinalIgnoreCase);
+        _groups = new Dictionary<string, MitsubishiTagGroupDefinition>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tag in tags)
+        {
+            Add(tag);
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of tags in the database.
+    /// </summary>
+    public int Count => _tags.Count;
+
+    /// <summary>
+    /// Gets the number of groups in the database.
+    /// </summary>
+    public int GroupCount => _groups.Count;
+
+    /// <summary>
+    /// Serializes the current schema, including groups, to JSON.
+    /// </summary>
+    /// <returns>JSON schema text.</returns>
+    public string ToJson() => MitsubishiTagDatabaseSerialization.ToJson(this);
+
+    /// <summary>
+    /// Serializes the current schema, including groups, to YAML.
+    /// </summary>
+    /// <returns>YAML schema text.</returns>
+    public string ToYaml() => MitsubishiTagDatabaseSerialization.ToYaml(this);
+
+    /// <summary>
+    /// Saves the current schema to a file using extension-based format detection.
+    /// Supported extensions: <c>.csv</c>, <c>.json</c>, <c>.yaml</c>, <c>.yml</c>.
+    /// </summary>
+    /// <param name="path">Target file path.</param>
+    public void Save(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(path, SerializeByExtension(path));
+    }
+
+    /// <summary>
+    /// Loads a tag database from a file using extension-based format detection.
+    /// Supported extensions: <c>.csv</c>, <c>.json</c>, <c>.yaml</c>, <c>.yml</c>.
+    /// </summary>
+    /// <param name="path">Source file path.</param>
+    /// <returns>Parsed tag database.</returns>
+    public static MitsubishiTagDatabase Load(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var content = File.ReadAllText(path);
+        return DeserializeByExtension(path, content);
+    }
+
+    /// <summary>
+    /// Compares this schema to another schema and returns a semantic diff.
+    /// </summary>
+    /// <param name="other">Schema to compare against.</param>
+    /// <returns>Semantic schema diff.</returns>
+    public MitsubishiTagDatabaseDiff CompareWith(MitsubishiTagDatabase other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        var addedTags = other.Tags
+            .Where(tag => !_tags.ContainsKey(tag.Name))
+            .OrderBy(tag => tag.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var removedTags = Tags
+            .Where(tag => !other._tags.ContainsKey(tag.Name))
+            .OrderBy(tag => tag.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var changedTags = Tags
+            .Where(tag => other._tags.TryGetValue(tag.Name, out var current) && current != tag)
+            .Select(tag => new MitsubishiTagChange(tag.Name, tag, other._tags[tag.Name]))
+            .OrderBy(change => change.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var addedGroups = other.Groups
+            .Where(group => !_groups.ContainsKey(group.Name))
+            .OrderBy(group => group.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var removedGroups = Groups
+            .Where(group => !other._groups.ContainsKey(group.Name))
+            .OrderBy(group => group.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var changedGroups = Groups
+            .Where(group => other._groups.TryGetValue(group.Name, out var current) && current != group)
+            .Select(group => new MitsubishiTagGroupChange(group.Name, group, other._groups[group.Name]))
+            .OrderBy(change => change.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new MitsubishiTagDatabaseDiff(
+            addedTags,
+            removedTags,
+            changedTags,
+            addedGroups,
+            removedGroups,
+            changedGroups);
+    }
+
+    /// <summary>
+    /// Gets all tags currently stored in the database.
+    /// </summary>
+    public IReadOnlyCollection<MitsubishiTagDefinition> Tags => _tags.Values;
+
+    /// <summary>
+    /// Gets all groups currently stored in the database.
+    /// </summary>
+    public IReadOnlyCollection<MitsubishiTagGroupDefinition> Groups => _groups.Values;
+
+    /// <summary>
+    /// Builds a tag database from CSV content.
+    /// </summary>
+    /// <param name="csvContent">CSV text with a header row.</param>
+    /// <returns>Parsed tag database.</returns>
+    public static MitsubishiTagDatabase FromCsv(string csvContent)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(csvContent);
+        var lines = csvContent.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n').Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length < 2)
+        {
+            throw new FormatException("CSV content must include a header row and at least one data row.");
+        }
+
+        var headers = ParseCsvLine(lines[0]);
+        var index = BuildHeaderIndex(headers);
+        var tags = new List<MitsubishiTagDefinition>();
+        for (var rowIndex = 1; rowIndex < lines.Length; rowIndex++)
+        {
+            var line = lines[rowIndex].Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            var values = ParseCsvLine(line);
+            if (values.All(static value => string.IsNullOrWhiteSpace(value)))
+            {
+                continue;
+            }
+
+            string Read(string name, bool required = false)
+            {
+                if (!index.TryGetValue(name, out var columnIndex) || columnIndex >= values.Count)
+                {
+                    if (required)
+                    {
+                        throw new FormatException($"CSV header '{name}' is required.");
+                    }
+
+                    return string.Empty;
+                }
+
+                var value = values[columnIndex].Trim();
+                if (required && value.Length == 0)
+                {
+                    throw new FormatException($"CSV row {rowIndex + 1} is missing required column '{name}'.");
+                }
+
+                return value;
+            }
+
+            tags.Add(new MitsubishiTagDefinition(
+                Name: Read("Name", required: true),
+                Address: Read("Address", required: true),
+                DataType: NormalizeDataType(NullIfEmpty(Read("DataType")), $"CSV row {rowIndex + 1}"),
+                Description: NullIfEmpty(Read("Description")),
+                Scale: ParseDouble(Read("Scale"), defaultValue: 1.0),
+                Offset: ParseDouble(Read("Offset"), defaultValue: 0.0),
+                Length: ParseNullableInt(Read("Length")),
+                Encoding: NormalizeEncoding(NullIfEmpty(Read("Encoding")), $"CSV row {rowIndex + 1}"),
+                Units: NullIfEmpty(Read("Units")),
+                Signed: ParseBool(Read("Signed"), defaultValue: false),
+                ByteOrder: NormalizeByteOrder(NullIfEmpty(Read("ByteOrder")), $"CSV row {rowIndex + 1}"),
+                Notes: NullIfEmpty(Read("Notes"))));
+        }
+
+        return new MitsubishiTagDatabase(tags);
+    }
+
+    /// <summary>
+    /// Builds a tag database from JSON schema text.
+    /// </summary>
+    /// <param name="json">JSON schema text.</param>
+    /// <returns>Parsed tag database.</returns>
+    public static MitsubishiTagDatabase FromJson(string json) => MitsubishiTagDatabaseSerialization.FromJson(json);
+
+    /// <summary>
+    /// Builds a tag database from YAML schema text.
+    /// </summary>
+    /// <param name="yaml">YAML schema text.</param>
+    /// <returns>Parsed tag database.</returns>
+    public static MitsubishiTagDatabase FromYaml(string yaml) => MitsubishiTagDatabaseSerialization.FromYaml(yaml);
+
+    /// <summary>
+    /// Adds or replaces a tag definition.
+    /// </summary>
+    /// <param name="tag">Tag definition.</param>
+    public void Add(MitsubishiTagDefinition tag)
+    {
+        ArgumentNullException.ThrowIfNull(tag);
+        if (string.IsNullOrWhiteSpace(tag.Name))
+        {
+            throw new ArgumentException("Tag name must not be empty.", nameof(tag));
+        }
+
+        if (string.IsNullOrWhiteSpace(tag.Address))
+        {
+            throw new ArgumentException("Tag address must not be empty.", nameof(tag));
+        }
+
+        var normalizedDataType = NormalizeDataType(tag.DataType, nameof(tag));
+        var normalizedEncoding = NormalizeEncoding(tag.Encoding, nameof(tag));
+        var normalizedByteOrder = NormalizeByteOrder(tag.ByteOrder, nameof(tag));
+        if (tag.Length is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tag), "Tag Length must be greater than zero when specified.");
+        }
+
+        _tags[tag.Name] = tag with
+        {
+            DataType = normalizedDataType,
+            Encoding = normalizedEncoding,
+            ByteOrder = normalizedByteOrder,
+        };
+    }
+
+    /// <summary>
+    /// Tries to resolve a tag definition by name.
+    /// </summary>
+    /// <param name="name">Tag name.</param>
+    /// <param name="tag">Resolved tag when found.</param>
+    /// <returns><c>true</c> if the tag exists.</returns>
+    public bool TryGet(string name, out MitsubishiTagDefinition tag)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return _tags.TryGetValue(name, out tag!);
+    }
+
+    /// <summary>
+    /// Resolves a tag definition by name.
+    /// </summary>
+    /// <param name="name">Tag name.</param>
+    /// <returns>The resolved tag definition.</returns>
+    public MitsubishiTagDefinition GetRequired(string name)
+    {
+        if (TryGet(name, out var tag))
+        {
+            return tag;
+        }
+
+        throw new KeyNotFoundException($"Tag '{name}' was not found in the Mitsubishi tag database.");
+    }
+
+    /// <summary>
+    /// Adds or replaces a named group definition.
+    /// </summary>
+    /// <param name="group">Group definition.</param>
+    public void AddGroup(MitsubishiTagGroupDefinition group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        if (string.IsNullOrWhiteSpace(group.Name))
+        {
+            throw new ArgumentException("Group name must not be empty.", nameof(group));
+        }
+
+        if (group.ResolvedTagNames.Count == 0)
+        {
+            throw new ArgumentException("Group must contain at least one tag name.", nameof(group));
+        }
+
+        if (group.ResolvedTagNames.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException("Group tag names must not be empty.", nameof(group));
+        }
+
+        _groups[group.Name] = new MitsubishiTagGroupDefinition(group.Name, group.ResolvedTagNames.ToArray());
+    }
+
+    /// <summary>
+    /// Tries to resolve a group definition by name.
+    /// </summary>
+    /// <param name="name">Group name.</param>
+    /// <param name="group">Resolved group when found.</param>
+    /// <returns><c>true</c> if the group exists.</returns>
+    public bool TryGetGroup(string name, out MitsubishiTagGroupDefinition group)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return _groups.TryGetValue(name, out group!);
+    }
+
+    /// <summary>
+    /// Resolves a group definition by name.
+    /// </summary>
+    /// <param name="name">Group name.</param>
+    /// <returns>The resolved group definition.</returns>
+    public MitsubishiTagGroupDefinition GetRequiredGroup(string name)
+    {
+        if (TryGetGroup(name, out var group))
+        {
+            return group;
+        }
+
+        throw new KeyNotFoundException($"Group '{name}' was not found in the Mitsubishi tag database.");
+    }
+
+    private static Dictionary<string, int> BuildHeaderIndex(IReadOnlyList<string> headers)
+    {
+        var index = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < headers.Count; i++)
+        {
+            index[headers[i].Trim()] = i;
+        }
+
+        return index;
+    }
+
+    private static List<string> ParseCsvLine(string line)
+    {
+        var result = new List<string>();
+        var current = new System.Text.StringBuilder();
+        var inQuotes = false;
+        for (var i = 0; i < line.Length; i++)
+        {
+            var ch = line[i];
+            if (ch == '"')
+            {
+                if (inQuotes && i + 1 < line.Length && line[i + 1] == '"')
+                {
+                    current.Append('"');
+                    i++;
+                }
+                else
+                {
+                    inQuotes = !inQuotes;
+                }
+
+                continue;
+            }
+
+            if (ch == ',' && !inQuotes)
+            {
+                result.Add(current.ToString());
+                current.Clear();
+                continue;
+            }
+
+            current.Append(ch);
+        }
+
+        result.Add(current.ToString());
+        return result;
+    }
+
+    private static double ParseDouble(string value, double defaultValue)
+        => string.IsNullOrWhiteSpace(value)
+            ? defaultValue
+            : double.Parse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
+
+    private static int? ParseNullableInt(string value)
+        => string.IsNullOrWhiteSpace(value)
+            ? null
+            : int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+
+    private static bool ParseBool(string value, bool defaultValue)
+        => string.IsNullOrWhiteSpace(value)
+            ? defaultValue
+            : bool.Parse(value);
+
+    private static string? NormalizeDataType(string? dataType, string context)
+    {
+        if (string.IsNullOrWhiteSpace(dataType))
+        {
+            return null;
+        }
+
+        if (SupportedDataTypes.TryGetValue(dataType.Trim(), out var normalized))
+        {
+            return normalized;
+        }
+
+        throw new FormatException($"{context} contains unsupported DataType '{dataType}'. Supported values: {string.Join(", ", SupportedDataTypes.Values)}.");
+    }
+
+    private static string? NormalizeEncoding(string? encoding, string context)
+    {
+        if (string.IsNullOrWhiteSpace(encoding))
+        {
+            return null;
+        }
+
+        if (SupportedEncodings.TryGetValue(encoding.Trim(), out var normalized))
+        {
+            return normalized;
+        }
+
+        throw new FormatException($"{context} contains unsupported Encoding '{encoding}'. Supported values: {string.Join(", ", SupportedEncodings.Values)}.");
+    }
+
+    private static string? NormalizeByteOrder(string? byteOrder, string context)
+    {
+        if (string.IsNullOrWhiteSpace(byteOrder))
+        {
+            return null;
+        }
+
+        if (SupportedByteOrders.TryGetValue(byteOrder.Trim(), out var normalized))
+        {
+            return normalized;
+        }
+
+        throw new FormatException($"{context} contains unsupported ByteOrder '{byteOrder}'. Supported values: {string.Join(", ", SupportedByteOrders.Values)}.");
+    }
+
+    private string SerializeByExtension(string path)
+        => GetSchemaFormat(path) switch
+        {
+            MitsubishiTagDatabaseSchemaFormat.Csv => ToCsv(),
+            MitsubishiTagDatabaseSchemaFormat.Json => ToJson(),
+            MitsubishiTagDatabaseSchemaFormat.Yaml => ToYaml(),
+            _ => throw new NotSupportedException($"Schema format for '{path}' is not supported."),
+        };
+
+    private static MitsubishiTagDatabase DeserializeByExtension(string path, string content)
+        => GetSchemaFormat(path) switch
+        {
+            MitsubishiTagDatabaseSchemaFormat.Csv => FromCsv(content),
+            MitsubishiTagDatabaseSchemaFormat.Json => FromJson(content),
+            MitsubishiTagDatabaseSchemaFormat.Yaml => FromYaml(content),
+            _ => throw new NotSupportedException($"Schema format for '{path}' is not supported."),
+        };
+
+    private string ToCsv()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Name,Address,DataType,Description,Scale,Offset,Length,Encoding,Units,Signed,ByteOrder,Notes");
+
+        foreach (var tag in _tags.Values)
+        {
+            builder
+                .Append(EscapeCsv(tag.Name)).Append(',')
+                .Append(EscapeCsv(tag.Address)).Append(',')
+                .Append(EscapeCsv(tag.DataType)).Append(',')
+                .Append(EscapeCsv(tag.Description)).Append(',')
+                .Append(tag.Scale.ToString(CultureInfo.InvariantCulture)).Append(',')
+                .Append(tag.Offset.ToString(CultureInfo.InvariantCulture)).Append(',')
+                .Append(tag.Length?.ToString(CultureInfo.InvariantCulture) ?? string.Empty).Append(',')
+                .Append(EscapeCsv(tag.Encoding)).Append(',')
+                .Append(EscapeCsv(tag.Units)).Append(',')
+                .Append(tag.Signed.ToString().ToLowerInvariant()).Append(',')
+                .Append(EscapeCsv(tag.ByteOrder)).Append(',')
+                .Append(EscapeCsv(tag.Notes))
+                .AppendLine();
+        }
+
+        return builder.ToString();
+    }
+
+    private static MitsubishiTagDatabaseSchemaFormat GetSchemaFormat(string path)
+    {
+        var extension = Path.GetExtension(path);
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            throw new NotSupportedException($"Schema path '{path}' must use one of: .csv, .json, .yaml, .yml.");
+        }
+
+        return extension.ToLowerInvariant() switch
+        {
+            ".csv" => MitsubishiTagDatabaseSchemaFormat.Csv,
+            ".json" => MitsubishiTagDatabaseSchemaFormat.Json,
+            ".yaml" or ".yml" => MitsubishiTagDatabaseSchemaFormat.Yaml,
+            _ => throw new NotSupportedException($"Schema format '{extension}' is not supported. Use .csv, .json, .yaml, or .yml."),
+        };
+    }
+
+    private static string EscapeCsv(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        if (value.IndexOfAny([',', '"', '\n', '\r']) < 0)
+        {
+            return value;
+        }
+
+        return $"\"{value.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+    }
+
+    private static string? NullIfEmpty(string value)
+        => string.IsNullOrWhiteSpace(value) ? null : value;
+}

--- a/src/MitsubishiRx/MitsubishiTagDatabaseDiff.cs
+++ b/src/MitsubishiRx/MitsubishiTagDatabaseDiff.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx;
+
+/// <summary>
+/// Represents a single changed tag definition between two schema versions.
+/// </summary>
+/// <param name="Name">Tag name.</param>
+/// <param name="Previous">Previous tag definition.</param>
+/// <param name="Current">Current tag definition.</param>
+public sealed record MitsubishiTagChange(string Name, MitsubishiTagDefinition? Previous, MitsubishiTagDefinition? Current)
+{
+    /// <summary>
+    /// Gets the semantic change classification for this tag change.
+    /// </summary>
+    public MitsubishiSchemaChangeKind ChangeKinds => ClassifyTagChange(Previous, Current);
+
+    private static MitsubishiSchemaChangeKind ClassifyTagChange(MitsubishiTagDefinition? previous, MitsubishiTagDefinition? current)
+    {
+        if (previous is null || current is null)
+        {
+            return MitsubishiSchemaChangeKind.StructureChange;
+        }
+
+        var kinds = MitsubishiSchemaChangeKind.None;
+        if (!string.Equals(previous.Address, current.Address, StringComparison.OrdinalIgnoreCase))
+        {
+            kinds |= MitsubishiSchemaChangeKind.AddressChange;
+        }
+
+        if (!string.Equals(previous.DataType, current.DataType, StringComparison.OrdinalIgnoreCase) ||
+            previous.Length != current.Length ||
+            !string.Equals(previous.Encoding, current.Encoding, StringComparison.OrdinalIgnoreCase) ||
+            previous.Signed != current.Signed ||
+            !string.Equals(previous.ByteOrder, current.ByteOrder, StringComparison.OrdinalIgnoreCase))
+        {
+            kinds |= MitsubishiSchemaChangeKind.DataTypeChange;
+        }
+
+        var metadataChanged = !string.Equals(previous.Description, current.Description, StringComparison.Ordinal) ||
+            previous.Scale != current.Scale ||
+            previous.Offset != current.Offset ||
+            !string.Equals(previous.Units, current.Units, StringComparison.Ordinal) ||
+            !string.Equals(previous.Notes, current.Notes, StringComparison.Ordinal);
+        if (metadataChanged && kinds == MitsubishiSchemaChangeKind.None)
+        {
+            kinds |= MitsubishiSchemaChangeKind.MetadataOnly;
+        }
+
+        return kinds;
+    }
+}
+
+/// <summary>
+/// Represents a single changed tag group definition between two schema versions.
+/// </summary>
+/// <param name="Name">Group name.</param>
+/// <param name="Previous">Previous group definition.</param>
+/// <param name="Current">Current group definition.</param>
+public sealed record MitsubishiTagGroupChange(string Name, MitsubishiTagGroupDefinition? Previous, MitsubishiTagGroupDefinition? Current)
+{
+    /// <summary>
+    /// Gets the semantic change classification for this group change.
+    /// </summary>
+    public MitsubishiSchemaChangeKind ChangeKinds =>
+        Previous is null || Current is null
+            ? MitsubishiSchemaChangeKind.StructureChange
+            : MitsubishiSchemaChangeKind.GroupMembershipChange;
+}
+
+/// <summary>
+/// Represents a semantic diff between two tag-database schema versions.
+/// </summary>
+/// <param name="AddedTags">Tags present only in the current schema.</param>
+/// <param name="RemovedTags">Tags present only in the previous schema.</param>
+/// <param name="ChangedTags">Tags present in both schemas with different definitions.</param>
+/// <param name="AddedGroups">Groups present only in the current schema.</param>
+/// <param name="RemovedGroups">Groups present only in the previous schema.</param>
+/// <param name="ChangedGroups">Groups present in both schemas with different definitions.</param>
+public sealed record MitsubishiTagDatabaseDiff(
+    IReadOnlyList<MitsubishiTagDefinition> AddedTags,
+    IReadOnlyList<MitsubishiTagDefinition> RemovedTags,
+    IReadOnlyList<MitsubishiTagChange> ChangedTags,
+    IReadOnlyList<MitsubishiTagGroupDefinition> AddedGroups,
+    IReadOnlyList<MitsubishiTagGroupDefinition> RemovedGroups,
+    IReadOnlyList<MitsubishiTagGroupChange> ChangedGroups)
+{
+    /// <summary>
+    /// Gets the aggregate semantic change classification for this diff.
+    /// </summary>
+    public MitsubishiSchemaChangeKind ChangeKinds
+    {
+        get
+        {
+            var kinds = MitsubishiSchemaChangeKind.None;
+
+            if (AddedTags.Count > 0 || RemovedTags.Count > 0 || AddedGroups.Count > 0 || RemovedGroups.Count > 0)
+            {
+                kinds |= MitsubishiSchemaChangeKind.StructureChange;
+            }
+
+            foreach (var change in ChangedTags)
+            {
+                kinds |= change.ChangeKinds;
+            }
+
+            foreach (var change in ChangedGroups)
+            {
+                kinds |= change.ChangeKinds;
+            }
+
+            return kinds;
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether any tag or group changes were detected.
+    /// </summary>
+    public bool HasChanges =>
+        AddedTags.Count > 0 ||
+        RemovedTags.Count > 0 ||
+        ChangedTags.Count > 0 ||
+        AddedGroups.Count > 0 ||
+        RemovedGroups.Count > 0 ||
+        ChangedGroups.Count > 0;
+
+    /// <summary>
+    /// Gets the total number of semantic changes in the diff.
+    /// </summary>
+    public int ChangeCount =>
+        AddedTags.Count +
+        RemovedTags.Count +
+        ChangedTags.Count +
+        AddedGroups.Count +
+        RemovedGroups.Count +
+        ChangedGroups.Count;
+
+    /// <summary>
+    /// Gets an empty schema diff.
+    /// </summary>
+    public static MitsubishiTagDatabaseDiff Empty { get; }
+        = new([], [], [], [], [], []);
+}

--- a/src/MitsubishiRx/MitsubishiTagDatabaseSchemaFormat.cs
+++ b/src/MitsubishiRx/MitsubishiTagDatabaseSchemaFormat.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx;
+
+internal enum MitsubishiTagDatabaseSchemaFormat
+{
+    Csv,
+    Json,
+    Yaml,
+}

--- a/src/MitsubishiRx/MitsubishiTagDatabaseSerialization.cs
+++ b/src/MitsubishiRx/MitsubishiTagDatabaseSerialization.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace MitsubishiRx;
+
+internal sealed class MitsubishiTagDatabaseDocument
+{
+    public List<MitsubishiTagDefinitionDocument>? Tags { get; set; }
+
+    public List<MitsubishiTagGroupDefinitionDocument>? Groups { get; set; }
+}
+
+internal sealed class MitsubishiTagDefinitionDocument
+{
+    public string? Name { get; set; }
+
+    public string? Address { get; set; }
+
+    public string? DataType { get; set; }
+
+    public string? Description { get; set; }
+
+    public double Scale { get; set; } = 1.0;
+
+    public double Offset { get; set; }
+
+    public int? Length { get; set; }
+
+    public string? Encoding { get; set; }
+
+    public string? Units { get; set; }
+
+    public bool Signed { get; set; }
+
+    public string? ByteOrder { get; set; }
+
+    public string? Notes { get; set; }
+
+    public MitsubishiTagDefinition ToModel()
+        => new(
+            Name ?? string.Empty,
+            Address ?? string.Empty,
+            DataType,
+            Description,
+            Scale,
+            Offset,
+            Length,
+            Encoding,
+            Units,
+            Signed,
+            ByteOrder,
+            Notes);
+
+    public static MitsubishiTagDefinitionDocument FromModel(MitsubishiTagDefinition model)
+        => new()
+        {
+            Name = model.Name,
+            Address = model.Address,
+            DataType = model.DataType,
+            Description = model.Description,
+            Scale = model.Scale,
+            Offset = model.Offset,
+            Length = model.Length,
+            Encoding = model.Encoding,
+            Units = model.Units,
+            Signed = model.Signed,
+            ByteOrder = model.ByteOrder,
+            Notes = model.Notes,
+        };
+}
+
+internal sealed class MitsubishiTagGroupDefinitionDocument
+{
+    public string? Name { get; set; }
+
+    public List<string>? TagNames { get; set; }
+
+    public MitsubishiTagGroupDefinition ToModel()
+        => new(Name ?? string.Empty, TagNames ?? new List<string>());
+
+    public static MitsubishiTagGroupDefinitionDocument FromModel(MitsubishiTagGroupDefinition model)
+        => new()
+        {
+            Name = model.Name,
+            TagNames = model.ResolvedTagNames.ToList(),
+        };
+}
+
+internal static class MitsubishiTagDatabaseSerialization
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static readonly ISerializer YamlSerializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+        .Build();
+
+    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    public static string ToJson(MitsubishiTagDatabase database)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        return JsonSerializer.Serialize(ToDocument(database), JsonOptions);
+    }
+
+    public static MitsubishiTagDatabase FromJson(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+        var document = JsonSerializer.Deserialize<MitsubishiTagDatabaseDocument>(json, JsonOptions)
+            ?? new MitsubishiTagDatabaseDocument();
+        return FromDocument(document);
+    }
+
+    public static string ToYaml(MitsubishiTagDatabase database)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        return YamlSerializer.Serialize(ToDocument(database));
+    }
+
+    public static MitsubishiTagDatabase FromYaml(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+        var document = YamlDeserializer.Deserialize<MitsubishiTagDatabaseDocument>(yaml)
+            ?? new MitsubishiTagDatabaseDocument();
+        return FromDocument(document);
+    }
+
+    private static MitsubishiTagDatabaseDocument ToDocument(MitsubishiTagDatabase database)
+        => new()
+        {
+            Tags = database.Tags.Select(MitsubishiTagDefinitionDocument.FromModel).ToList(),
+            Groups = database.Groups.Select(MitsubishiTagGroupDefinitionDocument.FromModel).ToList(),
+        };
+
+    private static MitsubishiTagDatabase FromDocument(MitsubishiTagDatabaseDocument document)
+    {
+        var database = new MitsubishiTagDatabase((document.Tags ?? new List<MitsubishiTagDefinitionDocument>()).Select(static tag => tag.ToModel()));
+        foreach (var group in document.Groups ?? new List<MitsubishiTagGroupDefinitionDocument>())
+        {
+            database.AddGroup(group.ToModel());
+        }
+
+        return database;
+    }
+}

--- a/src/MitsubishiRx/MitsubishiTagGroups.cs
+++ b/src/MitsubishiRx/MitsubishiTagGroups.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx;
+
+/// <summary>
+/// Named collection of tags used for grouped reads, validation, and scan-class style workflows.
+/// </summary>
+/// <param name="Name">Unique group name.</param>
+/// <param name="TagNames">Ordered tag names belonging to the group.</param>
+public sealed record MitsubishiTagGroupDefinition(string Name, IReadOnlyList<string> TagNames)
+{
+    /// <summary>
+    /// Gets the resolved ordered tag names.
+    /// </summary>
+    public IReadOnlyList<string> ResolvedTagNames => TagNames ?? Array.Empty<string>();
+}
+
+/// <summary>
+/// Snapshot of heterogeneous tag values returned from a grouped read.
+/// </summary>
+/// <param name="GroupName">Group name.</param>
+/// <param name="Values">Tag values keyed by tag name.</param>
+public sealed record MitsubishiTagGroupSnapshot(string GroupName, IReadOnlyDictionary<string, object?> Values)
+{
+    /// <summary>
+    /// Gets the tag names present in this snapshot.
+    /// </summary>
+    public IReadOnlyList<string> TagNames => Values.Keys.ToArray();
+
+    /// <summary>
+    /// Gets a required typed value by tag name.
+    /// </summary>
+    /// <typeparam name="T">Expected value type.</typeparam>
+    /// <param name="tagName">Tag name.</param>
+    /// <returns>Typed value.</returns>
+    public T GetRequired<T>(string tagName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tagName);
+        if (!Values.TryGetValue(tagName, out var value))
+        {
+            throw new KeyNotFoundException($"Tag '{tagName}' was not present in snapshot '{GroupName}'.");
+        }
+
+        if (value is T typed)
+        {
+            return typed;
+        }
+
+        throw new InvalidCastException($"Tag '{tagName}' in snapshot '{GroupName}' is of type '{value?.GetType().Name ?? "null"}', not '{typeof(T).Name}'.");
+    }
+}

--- a/src/MitsubishiRx/MitsubishiTagRolloutPolicy.cs
+++ b/src/MitsubishiRx/MitsubishiTagRolloutPolicy.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx;
+
+/// <summary>
+/// Semantic change categories used to classify tag-database rollout risk.
+/// </summary>
+[Flags]
+public enum MitsubishiSchemaChangeKind
+{
+    /// <summary>
+    /// No semantic changes detected.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Metadata-only changes such as description, units, notes, scale, or offset.
+    /// </summary>
+    MetadataOnly = 1 << 0,
+
+    /// <summary>
+    /// Device address changed.
+    /// </summary>
+    AddressChange = 1 << 1,
+
+    /// <summary>
+    /// Data type, string shape, signedness, byte order, or encoding changed.
+    /// </summary>
+    DataTypeChange = 1 << 2,
+
+    /// <summary>
+    /// Group membership/order changed.
+    /// </summary>
+    GroupMembershipChange = 1 << 3,
+
+    /// <summary>
+    /// Tag or group added/removed.
+    /// </summary>
+    StructureChange = 1 << 4,
+}
+
+/// <summary>
+/// Rollout policy for deciding which schema changes may be applied automatically.
+/// </summary>
+public enum MitsubishiTagRolloutPolicy
+{
+    /// <summary>
+    /// Allow all validated schema changes.
+    /// </summary>
+    AllowAll = 0,
+
+    /// <summary>
+    /// Allow only metadata and group membership changes; reject address, datatype, and structural changes.
+    /// </summary>
+    SafeMetadataAndGroups = 1,
+}

--- a/src/MitsubishiRx/MitsubishiTransport.cs
+++ b/src/MitsubishiRx/MitsubishiTransport.cs
@@ -1,0 +1,240 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Net.Sockets;
+
+namespace MitsubishiRx;
+
+/// <summary>
+/// Transport abstraction used by the Mitsubishi reactive client.
+/// </summary>
+public interface IMitsubishiTransport : IAsyncDisposable, IDisposable
+{
+    /// <summary>
+    /// Gets a value indicating whether the transport is connected.
+    /// </summary>
+    bool IsConnected { get; }
+
+    /// <summary>
+    /// Connects the transport.
+    /// </summary>
+    /// <param name="options">Client options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    ValueTask ConnectAsync(MitsubishiClientOptions options, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Disconnects the transport.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    ValueTask DisconnectAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Exchanges a request and response with the PLC.
+    /// </summary>
+    /// <param name="request">Encoded transport request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The raw response bytes.</returns>
+    ValueTask<byte[]> ExchangeAsync(MitsubishiTransportRequest request, CancellationToken cancellationToken = default);
+}
+
+internal sealed class SocketMitsubishiTransport : IMitsubishiTransport
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private Socket? _socket;
+    private MitsubishiClientOptions? _options;
+
+    public bool IsConnected => _socket?.Connected ?? false;
+
+    public async ValueTask ConnectAsync(MitsubishiClientOptions options, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _options = options;
+            await EnsureConnectedCoreAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await CloseSocketAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask<byte[]> ExchangeAsync(MitsubishiTransportRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (_options is null)
+        {
+            throw new InvalidOperationException("Transport is not configured.");
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await EnsureConnectedCoreAsync(cancellationToken).ConfigureAwait(false);
+
+            if (_socket is null)
+            {
+                throw new InvalidOperationException("Socket transport is not connected.");
+            }
+
+            await _socket.SendAsync(request.Payload, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+            return _options.TransportKind == MitsubishiTransportKind.Udp
+                ? await ReceiveUdpAsync(_socket, cancellationToken).ConfigureAwait(false)
+                : await ReceiveTcpAsync(_socket, request.ExpectedResponseLength, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        CloseSocketAsync().AsTask().GetAwaiter().GetResult();
+        _gate.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await CloseSocketAsync().ConfigureAwait(false);
+        _gate.Dispose();
+    }
+
+    private static async ValueTask<byte[]> ReceiveUdpAsync(Socket socket, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[8192];
+        var received = await socket.ReceiveAsync(buffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+        return buffer[..received];
+    }
+
+    private async ValueTask<byte[]> ReceiveTcpAsync(Socket socket, int? expectedResponseLength, CancellationToken cancellationToken)
+    {
+        if (_options is null)
+        {
+            throw new InvalidOperationException("Transport is not configured.");
+        }
+
+        if (expectedResponseLength.HasValue)
+        {
+            return await ReceiveExactlyAsync(socket, expectedResponseLength.Value, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (_options.DataCode == CommunicationDataCode.Ascii)
+        {
+            return await ReceiveAsciiTcpAsync(socket, _options.FrameType, cancellationToken).ConfigureAwait(false);
+        }
+
+        var prefixLength = _options.FrameType == MitsubishiFrameType.FourE ? 15 : 11;
+        var prefix = await ReceiveExactlyAsync(socket, prefixLength, cancellationToken).ConfigureAwait(false);
+        var totalLength = _options.FrameType switch
+        {
+            MitsubishiFrameType.ThreeE => prefixLength + BitConverter.ToUInt16(prefix, 7),
+            MitsubishiFrameType.FourE => prefixLength + BitConverter.ToUInt16(prefix, 11),
+            _ => prefixLength,
+        };
+
+        var remaining = totalLength - prefixLength;
+        if (remaining <= 0)
+        {
+            return prefix;
+        }
+
+        var payload = await ReceiveExactlyAsync(socket, remaining, cancellationToken).ConfigureAwait(false);
+        return prefix.Concat(payload).ToArray();
+    }
+
+    private static async ValueTask<byte[]> ReceiveAsciiTcpAsync(Socket socket, MitsubishiFrameType frameType, CancellationToken cancellationToken)
+    {
+        var prefixLength = frameType == MitsubishiFrameType.FourE ? 30 : 22;
+        var prefix = await ReceiveExactlyAsync(socket, prefixLength, cancellationToken).ConfigureAwait(false);
+        var prefixText = System.Text.Encoding.ASCII.GetString(prefix);
+        var lengthOffset = frameType == MitsubishiFrameType.FourE ? 22 : 14;
+        var responseDataLength = Convert.ToInt32(prefixText.Substring(lengthOffset, 4), 16);
+        var remainingAsciiChars = Math.Max(0, responseDataLength - 2) * 2;
+        if (remainingAsciiChars == 0)
+        {
+            return prefix;
+        }
+
+        var payload = await ReceiveExactlyAsync(socket, remainingAsciiChars, cancellationToken).ConfigureAwait(false);
+        return prefix.Concat(payload).ToArray();
+    }
+
+    private static async ValueTask<byte[]> ReceiveExactlyAsync(Socket socket, int count, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[count];
+        var read = 0;
+        while (read < count)
+        {
+            var received = await socket.ReceiveAsync(buffer.AsMemory(read, count - read), SocketFlags.None, cancellationToken).ConfigureAwait(false);
+            if (received == 0)
+            {
+                throw new IOException("The PLC connection dropped while waiting for response data.");
+            }
+
+            read += received;
+        }
+
+        return buffer;
+    }
+
+    private async ValueTask EnsureConnectedCoreAsync(CancellationToken cancellationToken)
+    {
+        if (IsConnected)
+        {
+            return;
+        }
+
+        if (_options is null)
+        {
+            throw new InvalidOperationException("Transport is not configured.");
+        }
+
+        await CloseSocketAsync().ConfigureAwait(false);
+        var protocolType = _options.TransportKind == MitsubishiTransportKind.Tcp ? ProtocolType.Tcp : ProtocolType.Udp;
+        var socketType = _options.TransportKind == MitsubishiTransportKind.Tcp ? SocketType.Stream : SocketType.Dgram;
+        _socket = new Socket(AddressFamily.InterNetwork, socketType, protocolType)
+        {
+            SendTimeout = (int)_options.ResolvedTimeout.TotalMilliseconds,
+            ReceiveTimeout = (int)_options.ResolvedTimeout.TotalMilliseconds,
+        };
+
+        var addresses = await Dns.GetHostAddressesAsync(_options.Host, cancellationToken).ConfigureAwait(false);
+        var address = addresses.FirstOrDefault(static a => a.AddressFamily == AddressFamily.InterNetwork)
+            ?? IPAddress.Parse(_options.Host);
+        await _socket.ConnectAsync(new IPEndPoint(address, _options.Port), cancellationToken).ConfigureAwait(false);
+    }
+
+    private ValueTask CloseSocketAsync()
+    {
+        try
+        {
+            _socket.SafeClose();
+            _socket = null;
+        }
+        catch
+        {
+            _socket = null;
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/MitsubishiRx/Mixins.cs
+++ b/src/MitsubishiRx/Mixins.cs
@@ -7,7 +7,7 @@ namespace MitsubishiRx
 {
     internal static class Mixins
     {
-        public static void SafeClose(this Socket socket)
+        public static void SafeClose(this Socket? socket)
         {
             try
             {

--- a/src/MitsubishiRx/ReactiveSerialMitsubishiTransport.cs
+++ b/src/MitsubishiRx/ReactiveSerialMitsubishiTransport.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace MitsubishiRx;
+
+internal sealed class ReactiveSerialMitsubishiTransport : IMitsubishiTransport
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private ReactiveSerialPortAdapter? _serialPort;
+    private MitsubishiClientOptions? _options;
+
+    public bool IsConnected => _serialPort?.IsOpen ?? false;
+
+    public async ValueTask ConnectAsync(MitsubishiClientOptions options, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.TransportKind != MitsubishiTransportKind.Serial)
+        {
+            throw new InvalidOperationException("Reactive serial transport requires TransportKind.Serial.");
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _options = options;
+            await EnsureConnectedCoreAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ClosePort();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask<byte[]> ExchangeAsync(MitsubishiTransportRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (_options is null)
+        {
+            throw new InvalidOperationException("Transport is not configured.");
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await EnsureConnectedCoreAsync(cancellationToken).ConfigureAwait(false);
+            if (_serialPort is null)
+            {
+                throw new InvalidOperationException("Serial transport is not connected.");
+            }
+
+            _serialPort.DiscardInBuffer();
+            _serialPort.DiscardOutBuffer();
+            _serialPort.Write(request.Payload);
+
+            var timeout = _options.ResolvedTimeout;
+            return await _serialPort.ReceivedBytes
+                .Scan(new List<byte>(), static (state, chunk) =>
+                {
+                    state.AddRange(chunk);
+                    return state;
+                })
+                .Where(buffer => MitsubishiSerialProtocolEncoding.IsExpectedFrameComplete(_options, buffer.ToArray()))
+                .Select(static buffer => buffer.ToArray())
+                .Timeout(timeout)
+                .FirstAsync()
+                .ToTask(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        ClosePort();
+        _gate.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        ClosePort();
+        _gate.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private async ValueTask EnsureConnectedCoreAsync(CancellationToken cancellationToken)
+    {
+        if (IsConnected)
+        {
+            return;
+        }
+
+        if (_options is null)
+        {
+            throw new InvalidOperationException("Transport is not configured.");
+        }
+
+        ClosePort();
+        _serialPort = new ReactiveSerialPortAdapter(_options.ResolvedSerial);
+        await _serialPort.OpenAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private void ClosePort()
+    {
+        try
+        {
+            _serialPort?.Dispose();
+        }
+        catch
+        {
+        }
+        finally
+        {
+            _serialPort = null;
+        }
+    }
+}

--- a/src/MitsubishiRx/ReactiveSerialPortAdapter.cs
+++ b/src/MitsubishiRx/ReactiveSerialPortAdapter.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Ports;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using CP.IO.Ports;
+
+namespace MitsubishiRx;
+
+internal sealed class ReactiveSerialPortAdapter : IDisposable
+{
+    private readonly ISerialPortRx _serialPort;
+    private readonly Subject<byte[]> _writes = new();
+
+    public ReactiveSerialPortAdapter(MitsubishiSerialOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _serialPort = new SerialPortRx(
+            options.PortName,
+            options.BaudRate,
+            options.DataBits,
+            options.Parity,
+            options.StopBits,
+            options.Handshake)
+        {
+            NewLine = options.NewLine,
+            ReadBufferSize = options.ReadBufferSize,
+            WriteBufferSize = options.WriteBufferSize,
+            ReceivedBytesThreshold = 1,
+            EnableAutoDataReceive = true,
+            ReadTimeout = SerialPort.InfiniteTimeout,
+            WriteTimeout = SerialPort.InfiniteTimeout,
+        };
+    }
+
+    public bool IsOpen => _serialPort.IsOpen;
+
+    public IObservable<byte[]> ReceivedBytes => _serialPort.DataReceivedBytes
+        .Select(static value => new byte[] { value });
+
+    public IObservable<byte[]> WrittenBytes => _writes.AsObservable();
+
+    public Task OpenAsync() => _serialPort.Open();
+
+    public void Close() => _serialPort.Close();
+
+    public void DiscardInBuffer() => _serialPort.DiscardInBuffer();
+
+    public void DiscardOutBuffer() => _serialPort.DiscardOutBuffer();
+
+    public void Write(byte[] buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        _serialPort.Write(buffer, 0, buffer.Length);
+        _writes.OnNext(buffer.ToArray());
+    }
+
+    public Task<int> ReadAsync(byte[] buffer, int offset, int count)
+        => _serialPort.ReadAsync(buffer, offset, count);
+
+    public void Dispose()
+    {
+        try
+        {
+            _serialPort.Close();
+        }
+        catch
+        {
+        }
+
+        _serialPort.Dispose();
+        _writes.OnCompleted();
+        _writes.Dispose();
+    }
+}

--- a/src/MitsubishiRx/Responce.cs
+++ b/src/MitsubishiRx/Responce.cs
@@ -26,7 +26,7 @@ namespace MitsubishiRx
         /// </value>
         public string Err
         {
-            get => _Err;
+            get => _Err ?? string.Empty;
             set
             {
                 _Err = value;

--- a/src/MitsubishiRx/ResponceExtensions.cs
+++ b/src/MitsubishiRx/ResponceExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx;
+
+internal static class ResponceExtensions
+{
+    public static Responce Fail(this Responce result, string error, int errorCode = 0, Exception? exception = null)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        result.IsSucceed = false;
+        result.ErrCode = errorCode;
+        result.Exception = exception;
+        result.Err = error;
+        return result.EndTime();
+    }
+
+    public static Responce<T> Fail<T>(this Responce<T> result, string error, int errorCode = 0, Exception? exception = null)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        result.IsSucceed = false;
+        result.ErrCode = errorCode;
+        result.Exception = exception;
+        result.Err = error;
+        return result.EndTime();
+    }
+
+    public static Responce ToBaseResponse(this Responce result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        var response = new Responce();
+        response.SetErrInfo(result);
+        return response.EndTime();
+    }
+}

--- a/tests/MitsubishiRx.Tests/FakeTransport.cs
+++ b/tests/MitsubishiRx.Tests/FakeTransport.cs
@@ -1,0 +1,64 @@
+using System.Collections.Concurrent;
+
+namespace MitsubishiRx.Tests;
+
+internal sealed class FakeTransport : IMitsubishiTransport
+{
+    private readonly ConcurrentQueue<byte[]> _responses;
+    private readonly Func<MitsubishiTransportRequest, byte[]>? _responseFactory;
+    private bool _connected;
+
+    public FakeTransport(IEnumerable<byte[]> responses)
+    {
+        _responses = new ConcurrentQueue<byte[]>(responses);
+    }
+
+    public FakeTransport(Func<MitsubishiTransportRequest, byte[]> responseFactory)
+    {
+        _responses = new ConcurrentQueue<byte[]>();
+        _responseFactory = responseFactory;
+    }
+
+    public List<MitsubishiTransportRequest> Requests { get; } = new();
+
+    public bool IsConnected => _connected;
+
+    public ValueTask ConnectAsync(MitsubishiClientOptions options, CancellationToken cancellationToken = default)
+    {
+        _connected = true;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
+    {
+        _connected = false;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<byte[]> ExchangeAsync(MitsubishiTransportRequest request, CancellationToken cancellationToken = default)
+    {
+        Requests.Add(request);
+        if (_responses.TryDequeue(out var response))
+        {
+            return ValueTask.FromResult(response);
+        }
+
+        if (_responseFactory is not null)
+        {
+            return ValueTask.FromResult(_responseFactory(request));
+        }
+
+        throw new InvalidOperationException("No fake response queued.");
+    }
+
+    public void Dispose()
+    {
+        _connected = false;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _connected = false;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiDeviceAddressTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiDeviceAddressTests.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiDeviceAddressTests
+{
+    [Test]
+    [Arguments("X10", XyAddressNotation.Octal, 8)]
+    [Arguments("X10", XyAddressNotation.Hexadecimal, 16)]
+    [Arguments("Y17", XyAddressNotation.Octal, 15)]
+    [Arguments("B10", XyAddressNotation.Hexadecimal, 16)]
+    [Arguments("D100", XyAddressNotation.Octal, 100)]
+    public async Task ParseUsesExpectedRadix(string value, XyAddressNotation notation, int expected)
+    {
+        var address = MitsubishiDeviceAddress.Parse(value, notation);
+
+        await Assert.That(address.Number).IsEqualTo(expected);
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiHardeningTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiHardeningTests.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiHardeningTests
+{
+    [Test]
+    public async Task RemoteRunAsyncEncodesAscii3EForceAndClearMode()
+    {
+        var transport = new FakeTransport(
+        [
+            System.Text.Encoding.ASCII.GetBytes("D00000FF03FF0000020000"),
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5010,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Ascii,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate);
+        var result = await client.RemoteRunAsync(force: true, clearMode: true);
+        if (!result.IsSucceed)
+        {
+            throw new InvalidOperationException(result.Err);
+        }
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(System.Text.Encoding.ASCII.GetString(transport.Requests[0].Payload)).IsEqualTo("500000FF03FF00000E00101001000000010001");
+    }
+
+    [Test]
+    public async Task RegisterMonitorAsyncEncodesAscii3EAddresses()
+    {
+        var transport = new FakeTransport(
+        [
+            System.Text.Encoding.ASCII.GetBytes("D00000FF03FF0000020000"),
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5011,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Ascii,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate);
+        var result = await client.RegisterMonitorAsync(["D100", "D101"]);
+        if (!result.IsSucceed)
+        {
+            throw new InvalidOperationException(result.Err);
+        }
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(System.Text.Encoding.ASCII.GetString(transport.Requests[0].Payload)).IsEqualTo("500000FF03FF00001A0010080100000200000064D*000065D*");
+    }
+
+    [Test]
+    public async Task RandomReadWordsAsyncPreservesHexadecimalXyNotation()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x06, 0x00, 0x00, 0x00, 0x34, 0x12, 0x78, 0x56],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5012,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010,
+            XyNotation: XyAddressNotation.Hexadecimal);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate);
+        var result = await client.RandomReadWordsAsync(["X10", "Y1F"]);
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests[0].Payload.Skip(15).Take(8).Select(static value => (int)value).ToArray()).IsEquivalentTo(
+        [0x02, 0x00, 0x10, 0x00, 0x00, 0x9C, 0x1F, 0x00]);
+    }
+
+    [Test]
+    public async Task ReadBlocksAsyncEncodesAscii3EBlockCounts()
+    {
+        var transport = new FakeTransport(
+        [
+            System.Text.Encoding.ASCII.GetBytes("D00000FF03FF0000020000"),
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5013,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Ascii,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var request = new MitsubishiBlockRequest(
+            WordBlocks:
+            [
+                new MitsubishiWordBlock(MitsubishiDeviceAddress.Parse("D100", XyAddressNotation.Octal), new ushort[2]),
+            ],
+            BitBlocks:
+            [
+                new MitsubishiBitBlock(MitsubishiDeviceAddress.Parse("M10", XyAddressNotation.Octal), new bool[3]),
+            ]);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate);
+        var result = await client.ReadBlocksAsync(request);
+        if (!result.IsSucceed)
+        {
+            throw new InvalidOperationException(result.Err);
+        }
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(System.Text.Encoding.ASCII.GetString(transport.Requests[0].Payload)).IsEqualTo("500000FF03FF00002600100406000000010001000064D*000200000AM*0003");
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiProtocolEncodingTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiProtocolEncodingTests.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiProtocolEncodingTests
+{
+    [Test]
+    public async Task ReadWordsAsyncEncodesBinary3ERequest()
+    {
+        var transport = new FakeTransport(
+        [
+            [
+                0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x06, 0x00, 0x00, 0x00, 0x34, 0x12, 0x78, 0x56,
+            ],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5000,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate);
+        var result = await client.ReadWordsAsync("D100", 2);
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value!.Select(static value => (int)value).ToArray()).IsEquivalentTo([0x1234, 0x5678]);
+        await Assert.That(transport.Requests.Count).IsEqualTo(1);
+        await Assert.That(transport.Requests[0].Payload.Select(static value => (int)value).ToArray()).IsEquivalentTo(
+        [
+            0x50, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x0C, 0x00, 0x10, 0x00, 0x01, 0x04, 0x00, 0x00, 0x64, 0x00, 0x00, 0xA8, 0x02, 0x00,
+        ]);
+    }
+
+    [Test]
+    public async Task ExecuteRawAsyncEncodesBinary4ERequestWithSerialNumber()
+    {
+        var transport = new FakeTransport(
+        [
+            [
+                0xD4, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00,
+            ],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5001,
+            FrameType: MitsubishiFrameType.FourE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010,
+            SerialNumberProvider: () => 0x1234);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate);
+        var result = await client.ExecuteRawAsync(new MitsubishiRawCommandRequest(0x0101, 0x0000));
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests.Count).IsEqualTo(1);
+        await Assert.That(transport.Requests[0].Payload.Select(static value => (int)value).ToArray()).IsEquivalentTo(
+        [
+            0x54, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x06, 0x00, 0x10, 0x00, 0x01, 0x01, 0x00, 0x00,
+        ]);
+    }
+
+    [Test]
+    public async Task ReadWordsAsyncEncodesBinary1ERequest()
+    {
+        var transport = new FakeTransport(
+        [
+            [0x81, 0x00, 0x34, 0x12, 0x78, 0x56],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5002,
+            FrameType: MitsubishiFrameType.OneE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            MonitoringTimer: 0x0010,
+            LegacyPcNumber: 0xFF);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate);
+        var result = await client.ReadWordsAsync("D100", 2);
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value!.Select(static value => (int)value).ToArray()).IsEquivalentTo([0x1234, 0x5678]);
+        await Assert.That(transport.Requests.Count).IsEqualTo(1);
+        await Assert.That(transport.Requests[0].Payload.Select(static value => (int)value).ToArray()).IsEquivalentTo(
+        [
+            0x01, 0xFF, 0x10, 0x00, 0x64, 0x00, 0x00, 0x00, 0x20, 0x44, 0x02, 0x00,
+        ]);
+        await Assert.That(transport.Requests[0].ExpectedResponseLength).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task ReadWordsAsyncParsesAscii3EResponse()
+    {
+        var asciiResponse = System.Text.Encoding.ASCII.GetBytes("D00000FF03FF000006000012345678");
+        var transport = new FakeTransport([asciiResponse]);
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5004,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Ascii,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate);
+        var result = await client.ReadWordsAsync("D100", 2);
+        if (!result.IsSucceed)
+        {
+            throw new InvalidOperationException(result.Err);
+        }
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value!.Select(static value => (int)value).ToArray()).IsEquivalentTo([0x1234, 0x5678]);
+        await Assert.That(System.Text.Encoding.ASCII.GetString(transport.Requests[0].Payload)).IsEqualTo("500000FF03FF000012001004010000000064D*0002");
+    }
+
+    [Test]
+    public async Task ReadMemoryAsyncEncodesRequestedLength()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x08, 0x00, 0x00, 0x00, 0x34, 0x12, 0x78, 0x56, 0xBC, 0x9A],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5005,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate);
+        var result = await client.ReadMemoryAsync(MitsubishiCommands.MemoryRead, 0x2000, 3);
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value!.Select(static value => (int)value).ToArray()).IsEquivalentTo([0x1234, 0x5678, 0x9ABC]);
+        await Assert.That(transport.Requests.Count).IsEqualTo(1);
+        var payload = transport.Requests[0].Payload;
+        await Assert.That(payload[15]).IsEqualTo((byte)0x00);
+        await Assert.That(payload[16]).IsEqualTo((byte)0x20);
+        await Assert.That(payload[17]).IsEqualTo((byte)0x03);
+        await Assert.That(payload[18]).IsEqualTo((byte)0x00);
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiReactivePollingTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiReactivePollingTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Microsoft.Reactive.Testing;
+using ReactiveUI.Extensions;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiReactivePollingTests
+{
+    [Test]
+    public async Task ObserveWordsHeartbeatEmitsHeartbeatBetweenPolls()
+    {
+        var scheduler = new TestScheduler();
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x34, 0x12],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x35, 0x12],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5003,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, scheduler);
+        var received = new List<IHeartbeat<Responce<ushort[]>>>();
+
+        using var subscription = client
+            .ObserveWordsHeartbeat("D100", 1, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10), TimeSpan.FromSeconds(30))
+            .Take(3)
+            .Subscribe(received.Add);
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(6).Ticks);
+
+        await Assert.That(received.Count).IsEqualTo(3);
+        await Assert.That(received[0].IsHeartbeat).IsFalse();
+        await Assert.That(received[1].IsHeartbeat).IsTrue();
+        await Assert.That(received[2].IsHeartbeat).IsTrue();
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiReactiveTagGroupTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiReactiveTagGroupTests.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Microsoft.Reactive.Testing;
+using ReactiveUI.Extensions;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiReactiveTagGroupTests
+{
+    [Test]
+    public async Task ObserveTagGroupHeartbeatEmitsHeartbeatBetweenPolls()
+    {
+        var scheduler = new TestScheduler();
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x34, 0x12],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x35, 0x12],
+        ]);
+
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("RecipeNumber", "D300", DataType: "UInt16"),
+        ]);
+        database.AddGroup(new MitsubishiTagGroupDefinition("Recipe", ["RecipeNumber"]));
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5037,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, scheduler)
+        {
+            TagDatabase = database,
+        };
+
+        var received = new List<IHeartbeat<Responce<MitsubishiTagGroupSnapshot>>>();
+
+        using var subscription = client
+            .ObserveTagGroupHeartbeat("Recipe", TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10))
+            .Take(3)
+            .Subscribe(received.Add);
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(6).Ticks);
+
+        await Assert.That(received.Count).IsEqualTo(3);
+        await Assert.That(received[0].IsHeartbeat).IsFalse();
+        var firstUpdate = received[0].Update;
+        if (firstUpdate is null || firstUpdate.Value is not MitsubishiTagGroupSnapshot firstSnapshot)
+        {
+            throw new InvalidOperationException("Expected first grouped heartbeat sample to contain a snapshot value.");
+        }
+
+        await Assert.That(firstSnapshot.GetRequired<ushort>("RecipeNumber")).IsEqualTo((ushort)0x1234);
+        await Assert.That(received[1].IsHeartbeat).IsTrue();
+        await Assert.That(received[2].IsHeartbeat).IsTrue();
+    }
+
+    [Test]
+    public async Task ObserveTagGroupStaleMarksStreamWhenUpdatesGoQuiet()
+    {
+        var scheduler = new TestScheduler();
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x34, 0x12],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x35, 0x12],
+        ]);
+
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("RecipeNumber", "D300", DataType: "UInt16"),
+        ]);
+        database.AddGroup(new MitsubishiTagGroupDefinition("Recipe", ["RecipeNumber"]));
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5038,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, scheduler)
+        {
+            TagDatabase = database,
+        };
+
+        var received = new List<IStale<Responce<MitsubishiTagGroupSnapshot>>>();
+
+        using var subscription = client
+            .ObserveTagGroupStale("Recipe", TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10))
+            .Take(2)
+            .Subscribe(received.Add);
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(3).Ticks);
+
+        await Assert.That(received.Count).IsEqualTo(2);
+        await Assert.That(received[0].IsStale).IsFalse();
+        await Assert.That(received[1].IsStale).IsTrue();
+    }
+
+    [Test]
+    public async Task ObserveTagGroupLatestUsesLatestCompletedSnapshot()
+    {
+        var scheduler = new TestScheduler();
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x34, 0x12],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x35, 0x12],
+        ]);
+
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("RecipeNumber", "D300", DataType: "UInt16"),
+        ]);
+        database.AddGroup(new MitsubishiTagGroupDefinition("Recipe", ["RecipeNumber"]));
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5039,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, scheduler)
+        {
+            TagDatabase = database,
+        };
+
+        var trigger = new Subject<Unit>();
+        var received = new List<Responce<MitsubishiTagGroupSnapshot>>();
+
+        using var subscription = client
+            .ObserveTagGroupLatest("Recipe", trigger)
+            .Take(2)
+            .Subscribe(received.Add);
+
+        trigger.OnNext(Unit.Default);
+        trigger.OnNext(Unit.Default);
+        scheduler.AdvanceBy(1);
+
+        await Assert.That(received.Count).IsEqualTo(2);
+        if (received[0].Value is not MitsubishiTagGroupSnapshot firstLatest)
+        {
+            throw new InvalidOperationException("Expected first latest-only grouped read to contain a snapshot.");
+        }
+
+        if (received[1].Value is not MitsubishiTagGroupSnapshot secondLatest)
+        {
+            throw new InvalidOperationException("Expected second latest-only grouped read to contain a snapshot.");
+        }
+
+        await Assert.That(firstLatest.GetRequired<ushort>("RecipeNumber")).IsEqualTo((ushort)0x1234);
+        await Assert.That(secondLatest.GetRequired<ushort>("RecipeNumber")).IsEqualTo((ushort)0x1235);
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiRx.Tests.csproj
+++ b/tests/MitsubishiRx.Tests/MitsubishiRx.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <RunAnalyzers>false</RunAnalyzers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/MitsubishiRx/MitsubishiRx.csproj" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.1.0" />
+    <PackageReference Include="TUnit" Version="1.*" />
+  </ItemGroup>
+</Project>

--- a/tests/MitsubishiRx.Tests/MitsubishiSerialSupportTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiSerialSupportTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiSerialSupportTests
+{
+    [Test]
+    public async Task SerialTransportKindEnumShouldExposeSerialMember()
+    {
+        await Assert.That(Enum.GetNames<MitsubishiTransportKind>()).Contains("Serial");
+    }
+
+    [Test]
+    public async Task SerialFrameTypesShouldExistForSerialMcProtocols()
+    {
+        await Assert.That(Enum.GetNames<MitsubishiFrameType>()).Contains("OneC");
+        await Assert.That(Enum.GetNames<MitsubishiFrameType>()).Contains("ThreeC");
+        await Assert.That(Enum.GetNames<MitsubishiFrameType>()).Contains("FourC");
+    }
+
+    [Test]
+    public async Task LibraryShouldDefineReactiveSerialOptionsType()
+    {
+        var assembly = typeof(MitsubishiRx).Assembly;
+        var serialOptionsType = assembly.GetType("MitsubishiRx.MitsubishiSerialOptions");
+        await Assert.That(serialOptionsType is not null).IsTrue();
+    }
+
+    [Test]
+    public async Task LibraryProjectShouldReferenceSerialportRxPackage()
+    {
+        var projectPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "MitsubishiRx", "MitsubishiRx.csproj");
+        projectPath = Path.GetFullPath(projectPath);
+        var projectText = await File.ReadAllTextAsync(projectPath);
+
+        await Assert.That(projectText.Contains("SerialPortRx", StringComparison.OrdinalIgnoreCase)).IsTrue();
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiTagDatabaseDiffTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiTagDatabaseDiffTests.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using Microsoft.Reactive.Testing;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiTagDatabaseDiffTests
+{
+    [Test]
+    public async Task CompareToReportsAddedRemovedAndChangedTagsAndGroups()
+    {
+        var current = CreateCurrentDatabase();
+        var updated = CreateUpdatedDatabase();
+
+        var diff = current.CompareWith(updated);
+
+        await Assert.That(diff.HasChanges).IsTrue();
+        await Assert.That(diff.AddedTags.Count).IsEqualTo(1);
+        await Assert.That(diff.RemovedTags.Count).IsEqualTo(1);
+        await Assert.That(diff.ChangedTags.Count).IsEqualTo(1);
+        await Assert.That(diff.AddedGroups.Count).IsEqualTo(1);
+        await Assert.That(diff.RemovedGroups.Count).IsEqualTo(1);
+        await Assert.That(diff.ChangedGroups.Count).IsEqualTo(1);
+
+        await Assert.That(diff.AddedTags[0].Name).IsEqualTo("OperatorMessage");
+        await Assert.That(diff.RemovedTags[0].Name).IsEqualTo("LegacyText");
+        await Assert.That(diff.ChangedTags[0].Name).IsEqualTo("MotorSpeed");
+        await Assert.That(diff.ChangedTags[0].Previous!.Address).IsEqualTo("D100");
+        await Assert.That(diff.ChangedTags[0].Current!.Address).IsEqualTo("D101");
+
+        await Assert.That(diff.AddedGroups[0].Name).IsEqualTo("Diagnostics");
+        await Assert.That(diff.RemovedGroups[0].Name).IsEqualTo("Legacy");
+        await Assert.That(diff.ChangedGroups[0].Name).IsEqualTo("Overview");
+    }
+
+    [Test]
+    public async Task PreviewTagDatabaseDiffReturnsChangesWithoutReplacingCurrentDatabase()
+    {
+        var path = CreateTempPath("json");
+        CreateUpdatedDatabase().Save(path);
+
+        var client = CreateClient(Scheduler.Immediate);
+        client.TagDatabase = CreateCurrentDatabase();
+
+        try
+        {
+            var result = client.PreviewTagDatabaseDiff(path);
+
+            await Assert.That(result.IsSucceed).IsTrue();
+            await Assert.That(result.Value is not null).IsTrue();
+            await Assert.That(result.Value!.ChangedTags.Count).IsEqualTo(1);
+            await Assert.That(result.Value.AddedTags[0].Name).IsEqualTo("OperatorMessage");
+            await Assert.That(client.TagDatabase!.GetRequired("MotorSpeed").Address).IsEqualTo("D100");
+            await Assert.That(client.TagDatabase.TryGet("OperatorMessage", out _)).IsFalse();
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task ObserveTagDatabaseDiffEmitsSemanticChangesAndAppliesSuccessfulReloads()
+    {
+        var scheduler = new TestScheduler();
+        var path = CreateTempPath("json");
+        CreateCurrentDatabase().Save(path);
+
+        var client = CreateClient(scheduler);
+        client.TagDatabase = CreateCurrentDatabase();
+        var received = new List<Responce<MitsubishiTagDatabaseDiff>>();
+
+        try
+        {
+            using var subscription = client
+                .ObserveTagDatabaseDiff(path, TimeSpan.FromSeconds(5), emitInitial: false)
+                .Take(1)
+                .Subscribe(received.Add);
+
+            CreateUpdatedDatabase().Save(path);
+            scheduler.AdvanceBy(TimeSpan.FromSeconds(5).Ticks + 1);
+
+            await Assert.That(received.Count).IsEqualTo(1);
+            await Assert.That(received[0].IsSucceed).IsTrue();
+            await Assert.That(received[0].Value is not null).IsTrue();
+            await Assert.That(received[0].Value!.ChangedTags.Count).IsEqualTo(1);
+            await Assert.That(received[0].Value!.AddedTags[0].Name).IsEqualTo("OperatorMessage");
+            await Assert.That(received[0].Value!.RemovedTags[0].Name).IsEqualTo("LegacyText");
+            await Assert.That(client.TagDatabase!.GetRequired("MotorSpeed").Address).IsEqualTo("D101");
+            await Assert.That(client.TagDatabase.TryGet("OperatorMessage", out _)).IsTrue();
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task ObserveTagDatabaseDiffEmitsFailureAndPreservesLastValidDatabaseOnInvalidReload()
+    {
+        var scheduler = new TestScheduler();
+        var path = CreateTempPath("json");
+        CreateCurrentDatabase().Save(path);
+
+        var client = CreateClient(scheduler);
+        client.TagDatabase = CreateCurrentDatabase();
+        var received = new List<Responce<MitsubishiTagDatabaseDiff>>();
+
+        try
+        {
+            using var subscription = client
+                .ObserveTagDatabaseDiff(path, TimeSpan.FromSeconds(5), emitInitial: false)
+                .Take(1)
+                .Subscribe(received.Add);
+
+            File.WriteAllText(path, """
+            {
+              "tags": [
+                {
+                  "name": "BrokenText",
+                  "address": "D600",
+                  "dataType": "String"
+                }
+              ]
+            }
+            """);
+            scheduler.AdvanceBy(TimeSpan.FromSeconds(5).Ticks + 1);
+
+            await Assert.That(received.Count).IsEqualTo(1);
+            await Assert.That(received[0].IsSucceed).IsFalse();
+            await Assert.That(received[0].Err.Contains("must define a positive Length", StringComparison.OrdinalIgnoreCase)).IsTrue();
+            await Assert.That(client.TagDatabase!.GetRequired("MotorSpeed").Address).IsEqualTo("D100");
+            await Assert.That(client.TagDatabase.TryGet("OperatorMessage", out _)).IsFalse();
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    private static MitsubishiRx CreateClient(IScheduler scheduler)
+    {
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5041,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010,
+            XyNotation: XyAddressNotation.Octal);
+
+        return new MitsubishiRx(options, new FakeTransport([]), scheduler);
+    }
+
+    private static MitsubishiTagDatabase CreateCurrentDatabase()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("MotorSpeed", "D100", DataType: "Word", Scale: 0.1, Units: "rpm"),
+            new MitsubishiTagDefinition("LegacyText", "D200", DataType: "String", Length: 2, Encoding: "Ascii"),
+        ]);
+
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["MotorSpeed", "LegacyText"]));
+        database.AddGroup(new MitsubishiTagGroupDefinition("Legacy", ["LegacyText"]));
+        return database;
+    }
+
+    private static MitsubishiTagDatabase CreateUpdatedDatabase()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("MotorSpeed", "D101", DataType: "Word", Scale: 0.1, Units: "rpm"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Length: 2, Encoding: "Utf8"),
+        ]);
+
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["MotorSpeed", "OperatorMessage"]));
+        database.AddGroup(new MitsubishiTagGroupDefinition("Diagnostics", ["OperatorMessage"]));
+        return database;
+    }
+
+    private static string CreateTempPath(string extension)
+        => Path.Combine(Path.GetTempPath(), $"mitsubishirx-diff-{Guid.NewGuid():N}.{extension}");
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiTagDatabaseReloadTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiTagDatabaseReloadTests.cs
@@ -1,0 +1,193 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using Microsoft.Reactive.Testing;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiTagDatabaseReloadTests
+{
+    [Test]
+    public async Task LoadAndValidateAppliesLoadedDatabaseWhenSchemaIsValid()
+    {
+        var path = CreateTempPath("json");
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("MotorSpeed", "D100", DataType: "Word", Scale: 0.1, Units: "rpm"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Length: 2, Encoding: "Utf8"),
+        ]);
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["MotorSpeed", "OperatorMessage"]));
+        database.Save(path);
+
+        var client = CreateClient(Scheduler.Immediate);
+
+        try
+        {
+            var result = client.LoadAndValidateTagDatabase(path);
+
+            await Assert.That(result.IsSucceed).IsTrue();
+            await Assert.That(client.TagDatabase is not null).IsTrue();
+            await Assert.That(client.TagDatabase!.Count).IsEqualTo(2);
+            await Assert.That(client.TagDatabase.GroupCount).IsEqualTo(1);
+            await Assert.That(client.TagDatabase.GetRequired("OperatorMessage").Encoding).IsEqualTo("Utf8");
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task LoadAndValidateReturnsErrorsAndDoesNotReplaceExistingDatabaseWhenSchemaIsInvalid()
+    {
+        var path = CreateTempPath("json");
+        File.WriteAllText(path, """
+        {
+          "tags": [
+            {
+              "name": "BadString",
+              "address": "D100",
+              "dataType": "String"
+            }
+          ]
+        }
+        """);
+
+        var existing = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("ExistingTag", "D200", DataType: "UInt16"),
+        ]);
+
+        var client = CreateClient(Scheduler.Immediate);
+        client.TagDatabase = existing;
+
+        try
+        {
+            var result = client.LoadAndValidateTagDatabase(path);
+
+            await Assert.That(result.IsSucceed).IsFalse();
+            await Assert.That(result.Err.Contains("must define a positive Length", StringComparison.OrdinalIgnoreCase)).IsTrue();
+            await Assert.That(ReferenceEquals(client.TagDatabase, existing)).IsTrue();
+            await Assert.That(client.TagDatabase!.GetRequired("ExistingTag").Address).IsEqualTo("D200");
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task ObserveTagDatabaseReloadEmitsSuccessfulReloadsWhenSchemaChanges()
+    {
+        var scheduler = new TestScheduler();
+        var path = CreateTempPath("json");
+        CreateDatabase("MotorSpeed", "D100").Save(path);
+
+        var client = CreateClient(scheduler);
+        var received = new List<Responce<MitsubishiTagDatabase>>();
+
+        try
+        {
+            using var subscription = client
+                .ObserveTagDatabaseReload(path, TimeSpan.FromSeconds(5), emitInitial: true)
+                .Take(2)
+                .Subscribe(received.Add);
+
+            scheduler.AdvanceBy(1);
+            CreateDatabase("MotorSpeed", "D101").Save(path);
+            scheduler.AdvanceBy(TimeSpan.FromSeconds(5).Ticks + 1);
+
+            await Assert.That(received.Count).IsEqualTo(2);
+            await Assert.That(received[0].IsSucceed).IsTrue();
+            await Assert.That(received[1].IsSucceed).IsTrue();
+            await Assert.That(received[0].Value!.GetRequired("MotorSpeed").Address).IsEqualTo("D100");
+            await Assert.That(received[1].Value!.GetRequired("MotorSpeed").Address).IsEqualTo("D101");
+            await Assert.That(client.TagDatabase!.GetRequired("MotorSpeed").Address).IsEqualTo("D101");
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task ObserveTagDatabaseReloadEmitsFailureForInvalidUpdateAndPreservesLastValidDatabase()
+    {
+        var scheduler = new TestScheduler();
+        var path = CreateTempPath("json");
+        CreateDatabase("MotorSpeed", "D100").Save(path);
+
+        var client = CreateClient(scheduler);
+        var received = new List<Responce<MitsubishiTagDatabase>>();
+
+        try
+        {
+            using var subscription = client
+                .ObserveTagDatabaseReload(path, TimeSpan.FromSeconds(5), emitInitial: true)
+                .Take(2)
+                .Subscribe(received.Add);
+
+            scheduler.AdvanceBy(1);
+            File.WriteAllText(path, """
+            {
+              "tags": [
+                {
+                  "name": "BrokenText",
+                  "address": "D600",
+                  "dataType": "String"
+                }
+              ]
+            }
+            """);
+            scheduler.AdvanceBy(TimeSpan.FromSeconds(5).Ticks + 1);
+
+            await Assert.That(received.Count).IsEqualTo(2);
+            await Assert.That(received[0].IsSucceed).IsTrue();
+            await Assert.That(received[1].IsSucceed).IsFalse();
+            await Assert.That(received[1].Err.Contains("must define a positive Length", StringComparison.OrdinalIgnoreCase)).IsTrue();
+            await Assert.That(client.TagDatabase!.GetRequired("MotorSpeed").Address).IsEqualTo("D100");
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    private static MitsubishiRx CreateClient(IScheduler scheduler)
+    {
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5040,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010,
+            XyNotation: XyAddressNotation.Octal);
+
+        return new MitsubishiRx(options, new FakeTransport([]), scheduler);
+    }
+
+    private static MitsubishiTagDatabase CreateDatabase(string tagName, string address)
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition(tagName, address, DataType: "Word", Scale: 0.1, Units: "rpm"),
+        ]);
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", [tagName]));
+        return database;
+    }
+
+    private static string CreateTempPath(string extension)
+        => Path.Combine(Path.GetTempPath(), $"mitsubishirx-reload-{Guid.NewGuid():N}.{extension}");
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiTagDatabaseRolloutPolicyTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiTagDatabaseRolloutPolicyTests.cs
@@ -1,0 +1,193 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using Microsoft.Reactive.Testing;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiTagDatabaseRolloutPolicyTests
+{
+    [Test]
+    public async Task CompareWithClassifiesMetadataAddressDatatypeAndGroupMembershipChanges()
+    {
+        var current = CreatePolicyCurrentDatabase();
+        var updated = CreatePolicyUpdatedDatabase();
+
+        var diff = current.CompareWith(updated);
+
+        await Assert.That(diff.ChangeKinds.HasFlag(MitsubishiSchemaChangeKind.MetadataOnly)).IsTrue();
+        await Assert.That(diff.ChangeKinds.HasFlag(MitsubishiSchemaChangeKind.AddressChange)).IsTrue();
+        await Assert.That(diff.ChangeKinds.HasFlag(MitsubishiSchemaChangeKind.DataTypeChange)).IsTrue();
+        await Assert.That(diff.ChangeKinds.HasFlag(MitsubishiSchemaChangeKind.GroupMembershipChange)).IsTrue();
+
+        var metadataChange = diff.ChangedTags.Single(change => change.Name == "OperatorMessage");
+        var addressChange = diff.ChangedTags.Single(change => change.Name == "MotorSpeed");
+        var dataTypeChange = diff.ChangedTags.Single(change => change.Name == "ProcessValue");
+
+        await Assert.That(metadataChange.ChangeKinds).IsEqualTo(MitsubishiSchemaChangeKind.MetadataOnly);
+        await Assert.That(addressChange.ChangeKinds.HasFlag(MitsubishiSchemaChangeKind.AddressChange)).IsTrue();
+        await Assert.That(dataTypeChange.ChangeKinds.HasFlag(MitsubishiSchemaChangeKind.DataTypeChange)).IsTrue();
+        await Assert.That(diff.ChangedGroups.Single().ChangeKinds).IsEqualTo(MitsubishiSchemaChangeKind.GroupMembershipChange);
+    }
+
+    [Test]
+    public async Task PreviewTagDatabaseDiffWithSafeMetadataAndGroupsPolicyRejectsAddressAndDatatypeChanges()
+    {
+        var path = CreateTempPath("json");
+        CreatePolicyUpdatedDatabase().Save(path);
+
+        var client = CreateClient(Scheduler.Immediate);
+        client.TagDatabase = CreatePolicyCurrentDatabase();
+
+        try
+        {
+            var result = client.PreviewTagDatabaseDiff(path, MitsubishiTagRolloutPolicy.SafeMetadataAndGroups);
+
+            await Assert.That(result.IsSucceed).IsFalse();
+            await Assert.That(result.Value is not null).IsTrue();
+            await Assert.That(result.Value!.ChangeKinds.HasFlag(MitsubishiSchemaChangeKind.AddressChange)).IsTrue();
+            await Assert.That(result.Value.ChangeKinds.HasFlag(MitsubishiSchemaChangeKind.DataTypeChange)).IsTrue();
+            await Assert.That(result.Err.Contains("AddressChange", StringComparison.OrdinalIgnoreCase)).IsTrue();
+            await Assert.That(result.Err.Contains("DataTypeChange", StringComparison.OrdinalIgnoreCase)).IsTrue();
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task LoadAndValidateTagDatabaseWithSafeMetadataAndGroupsPolicyAppliesAllowedChanges()
+    {
+        var path = CreateTempPath("json");
+        CreateMetadataAndGroupOnlyDatabase().Save(path);
+
+        var client = CreateClient(Scheduler.Immediate);
+        client.TagDatabase = CreatePolicyCurrentDatabase();
+
+        try
+        {
+            var result = client.LoadAndValidateTagDatabase(path, MitsubishiTagRolloutPolicy.SafeMetadataAndGroups);
+
+            await Assert.That(result.IsSucceed).IsTrue();
+            await Assert.That(client.TagDatabase!.GetRequired("OperatorMessage").Description).IsEqualTo("Updated HMI text");
+            await Assert.That(client.TagDatabase.GetRequiredGroup("Overview").ResolvedTagNames).IsEquivalentTo(new[] { "MotorSpeed", "OperatorMessage" });
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task ObserveTagDatabaseReloadWithSafeMetadataAndGroupsPolicyRejectsAddressChangeAndPreservesDatabase()
+    {
+        var scheduler = new TestScheduler();
+        var path = CreateTempPath("json");
+        CreatePolicyCurrentDatabase().Save(path);
+
+        var client = CreateClient(scheduler);
+        client.TagDatabase = CreatePolicyCurrentDatabase();
+        var received = new List<Responce<MitsubishiTagDatabase>>();
+
+        try
+        {
+            using var subscription = client
+                .ObserveTagDatabaseReload(path, TimeSpan.FromSeconds(5), emitInitial: false, policy: MitsubishiTagRolloutPolicy.SafeMetadataAndGroups)
+                .Take(1)
+                .Subscribe(received.Add);
+
+            CreateAddressOnlyUpdatedDatabase().Save(path);
+            scheduler.AdvanceBy(TimeSpan.FromSeconds(5).Ticks + 1);
+
+            await Assert.That(received.Count).IsEqualTo(1);
+            await Assert.That(received[0].IsSucceed).IsFalse();
+            await Assert.That(received[0].Err.Contains("AddressChange", StringComparison.OrdinalIgnoreCase)).IsTrue();
+            await Assert.That(client.TagDatabase!.GetRequired("MotorSpeed").Address).IsEqualTo("D100");
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    private static MitsubishiRx CreateClient(IScheduler scheduler)
+    {
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5042,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010,
+            XyNotation: XyAddressNotation.Octal);
+
+        return new MitsubishiRx(options, new FakeTransport([]), scheduler);
+    }
+
+    private static MitsubishiTagDatabase CreatePolicyCurrentDatabase()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("MotorSpeed", "D100", DataType: "Word", Description: "Main spindle RPM", Scale: 0.1, Units: "rpm"),
+            new MitsubishiTagDefinition("ProcessValue", "D300", DataType: "Word", Description: "Raw process value"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Description: "Current HMI text", Length: 2, Encoding: "Utf8"),
+        ]);
+
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["MotorSpeed", "ProcessValue"]));
+        return database;
+    }
+
+    private static MitsubishiTagDatabase CreatePolicyUpdatedDatabase()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("MotorSpeed", "D101", DataType: "Word", Description: "Main spindle RPM", Scale: 0.1, Units: "rpm"),
+            new MitsubishiTagDefinition("ProcessValue", "D300", DataType: "Float", Description: "Engineering process value"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Description: "Updated HMI text", Length: 2, Encoding: "Utf8"),
+        ]);
+
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["MotorSpeed", "OperatorMessage"]));
+        return database;
+    }
+
+    private static MitsubishiTagDatabase CreateMetadataAndGroupOnlyDatabase()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("MotorSpeed", "D100", DataType: "Word", Description: "Main spindle RPM", Scale: 0.1, Units: "rpm"),
+            new MitsubishiTagDefinition("ProcessValue", "D300", DataType: "Word", Description: "Raw process value"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Description: "Updated HMI text", Length: 2, Encoding: "Utf8"),
+        ]);
+
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["MotorSpeed", "OperatorMessage"]));
+        return database;
+    }
+
+    private static MitsubishiTagDatabase CreateAddressOnlyUpdatedDatabase()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("MotorSpeed", "D101", DataType: "Word", Description: "Main spindle RPM", Scale: 0.1, Units: "rpm"),
+            new MitsubishiTagDefinition("ProcessValue", "D300", DataType: "Word", Description: "Raw process value"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Description: "Current HMI text", Length: 2, Encoding: "Utf8"),
+        ]);
+
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["MotorSpeed", "ProcessValue"]));
+        return database;
+    }
+
+    private static string CreateTempPath(string extension)
+        => Path.Combine(Path.GetTempPath(), $"mitsubishirx-policy-{Guid.NewGuid():N}.{extension}");
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiTagDatabaseTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiTagDatabaseTests.cs
@@ -1,0 +1,790 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiTagDatabaseTests
+{
+    [Test]
+    public async Task CsvImportBuildsTagDatabaseAndPreservesMetadata()
+    {
+        var csv = """
+Name,Address,DataType,Description,Scale,Offset,Notes
+MotorSpeed,D100,Word,Main spindle RPM,0.1,0,From commissioning sheet
+PumpRunning,M10,Bit,Coolant pump running,1,0,
+HeadTemp,D200,Word,Head temperature,1.0,-10,Degrees C
+""";
+
+        var database = MitsubishiTagDatabase.FromCsv(csv);
+        var speed = database.GetRequired("MotorSpeed");
+        var pump = database.GetRequired("PumpRunning");
+
+        await Assert.That(database.Count).IsEqualTo(3);
+        await Assert.That(speed.Address).IsEqualTo("D100");
+        await Assert.That(speed.DataType).IsEqualTo("Word");
+        await Assert.That(speed.Description).IsEqualTo("Main spindle RPM");
+        await Assert.That(speed.Scale).IsEqualTo(0.1);
+        await Assert.That(speed.Offset).IsEqualTo(0.0);
+        await Assert.That(speed.Notes).IsEqualTo("From commissioning sheet");
+        await Assert.That(pump.Address).IsEqualTo("M10");
+        await Assert.That(pump.DataType).IsEqualTo("Bit");
+    }
+
+    [Test]
+    public async Task CsvImportNormalizesSupportedDataTypeValues()
+    {
+        var database = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+MotorSpeed,D100,word
+PumpRunning,M10,bIt
+RecipeNumber,D300,dword
+""");
+
+        await Assert.That(database.GetRequired("MotorSpeed").DataType).IsEqualTo("Word");
+        await Assert.That(database.GetRequired("PumpRunning").DataType).IsEqualTo("Bit");
+        await Assert.That(database.GetRequired("RecipeNumber").DataType).IsEqualTo("DWord");
+    }
+
+    [Test]
+    public async Task CsvImportRejectsUnknownDataTypeValues()
+    {
+        try
+        {
+            _ = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+MotorSpeed,D100,Boolean
+""");
+            throw new InvalidOperationException("Expected CSV import to reject unknown DataType values.");
+        }
+        catch (FormatException exception)
+        {
+            await Assert.That(exception.Message.Contains("DataType", StringComparison.OrdinalIgnoreCase)).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task ReadWordsByTagAsyncUsesResolvedTagAddress()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x06, 0x00, 0x00, 0x00, 0x34, 0x12, 0x78, 0x56],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5015,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var tags = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,Description
+MotorSpeed,D100,Word,Main spindle RPM
+""");
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = tags,
+        };
+
+        var result = await client.ReadWordsByTagAsync("MotorSpeed", 2);
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value!.Select(static value => (int)value).ToArray()).IsEquivalentTo(new[] { 0x1234, 0x5678 });
+        await Assert.That(transport.Requests.Count).IsEqualTo(1);
+        await Assert.That(transport.Requests[0].Description).IsEqualTo("Read words D100");
+    }
+
+    [Test]
+    public async Task ReadBitsByTagAsyncUsesResolvedTagAddress()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x03, 0x00, 0x00, 0x00, 0x11],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5016,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,Description
+PumpRunning,M10,Bit,Coolant pump running
+"""),
+        };
+
+        var result = await client.ReadBitsByTagAsync("PumpRunning", 2);
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value!).IsEquivalentTo(new[] { true, true });
+        await Assert.That(transport.Requests[0].Description).IsEqualTo("Read bits M10");
+    }
+
+    [Test]
+    public async Task WriteWordsByTagAsyncUsesResolvedTagAddress()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5017,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+MotorSpeed,D100,Word
+"""),
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baseline = await rawClient.WriteWordsAsync("D100", [0x1234, 0x5678]);
+        var result = await client.WriteWordsByTagAsync("MotorSpeed", [0x1234, 0x5678]);
+
+        await Assert.That(baseline.IsSucceed).IsTrue();
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests[0].Description).IsEqualTo("Write words D100");
+        await Assert.That(transport.Requests[0].Payload).IsEquivalentTo(rawTransport.Requests[0].Payload);
+    }
+
+    [Test]
+    public async Task WriteBitsByTagAsyncUsesResolvedTagAddress()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5018,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+PumpRunning,M10,Bit
+"""),
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baseline = await rawClient.WriteBitsAsync("M10", [true, false, true, true]);
+        var result = await client.WriteBitsByTagAsync("PumpRunning", [true, false, true, true]);
+
+        await Assert.That(baseline.IsSucceed).IsTrue();
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests[0].Description).IsEqualTo("Write bits M10");
+        await Assert.That(transport.Requests[0].Payload).IsEquivalentTo(rawTransport.Requests[0].Payload);
+    }
+
+    [Test]
+    public async Task RandomReadWordsByTagAsyncUsesResolvedAddressesInRequestOrder()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x34, 0x12],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5019,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+MotorSpeed,D100,Word
+RecipeNumber,D300,Word
+"""),
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x34, 0x12],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baseline = await rawClient.RandomReadWordsAsync(["D100", "D300"]);
+        var result = await client.RandomReadWordsByTagAsync(["MotorSpeed", "RecipeNumber"]);
+
+        await Assert.That(baseline.IsSucceed).IsTrue();
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value!.Select(static value => (int)value).ToArray()).IsEquivalentTo(new[] { 0x1234 });
+        await Assert.That(transport.Requests[0].Payload).IsEquivalentTo(rawTransport.Requests[0].Payload);
+    }
+
+    [Test]
+    public async Task RandomWriteWordsByTagAsyncUsesResolvedAddressesInRequestOrder()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5020,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+MotorSpeed,D100,Word
+RecipeNumber,D300,Word
+"""),
+        };
+
+        var values = new[]
+        {
+            new KeyValuePair<string, ushort>("MotorSpeed", 0x1234),
+            new KeyValuePair<string, ushort>("RecipeNumber", 0x5678),
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baseline = await rawClient.RandomWriteWordsAsync(
+        [
+            new KeyValuePair<string, ushort>("D100", 0x1234),
+            new KeyValuePair<string, ushort>("D300", 0x5678),
+        ]);
+        var result = await client.RandomWriteWordsByTagAsync(values);
+
+        await Assert.That(baseline.IsSucceed).IsTrue();
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests[0].Payload).IsEquivalentTo(rawTransport.Requests[0].Payload);
+    }
+
+    [Test]
+    public async Task ReadDWordByTagAsyncReadsLittleEndianDoubleWord()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x06, 0x00, 0x00, 0x00, 0x78, 0x56, 0x34, 0x12],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5021,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+TotalCount,D400,DWord
+"""),
+        };
+
+        var result = await client.ReadDWordByTagAsync("TotalCount");
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value).IsEqualTo(0x12345678u);
+    }
+
+    [Test]
+    public async Task WriteDWordByTagAsyncEncodesLittleEndianDoubleWord()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5022,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+TotalCount,D400,DWord
+"""),
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baseline = await rawClient.WriteWordsAsync("D400", [0x5678, 0x1234]);
+        var result = await client.WriteDWordByTagAsync("TotalCount", 0x12345678u);
+
+        await Assert.That(baseline.IsSucceed).IsTrue();
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests[0].Payload).IsEquivalentTo(rawTransport.Requests[0].Payload);
+    }
+
+    [Test]
+    public async Task ReadFloatByTagAsyncReadsLittleEndianSinglePrecisionValue()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5023,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+ProcessValue,D500,Float
+"""),
+        };
+
+        var result = await client.ReadFloatByTagAsync("ProcessValue");
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value).IsEqualTo(12.5f);
+    }
+
+    [Test]
+    public async Task WriteFloatByTagAsyncEncodesLittleEndianSinglePrecisionValue()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5024,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+ProcessValue,D500,Float
+"""),
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baseline = await rawClient.WriteWordsAsync("D500", [0x0000, 0x4148]);
+        var result = await client.WriteFloatByTagAsync("ProcessValue", 12.5f);
+
+        await Assert.That(baseline.IsSucceed).IsTrue();
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests[0].Payload).IsEquivalentTo(rawTransport.Requests[0].Payload);
+    }
+
+    [Test]
+    public async Task ReadScaledDoubleByTagAsyncAppliesScaleAndOffset()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0xFA, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5025,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,Scale,Offset
+HeadTemp,D200,Word,0.1,-10
+"""),
+        };
+
+        var result = await client.ReadScaledDoubleByTagAsync("HeadTemp");
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value).IsEqualTo(15.0d);
+    }
+
+    [Test]
+    public async Task WriteScaledDoubleByTagAsyncAppliesInverseScaleAndOffset()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5026,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,Scale,Offset
+HeadTemp,D200,Word,0.1,-10
+"""),
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baseline = await rawClient.WriteWordsAsync("D200", [250]);
+        var result = await client.WriteScaledDoubleByTagAsync("HeadTemp", 15.0d);
+
+        await Assert.That(baseline.IsSucceed).IsTrue();
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests[0].Payload).IsEquivalentTo(rawTransport.Requests[0].Payload);
+    }
+
+    [Test]
+    public async Task ReadStringByTagAsyncDecodesPackedAsciiWords()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x06, 0x00, 0x00, 0x00, 0x4F, 0x4B, 0x21, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5027,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+OperatorMessage,D600,String
+"""),
+        };
+
+        var result = await client.ReadStringByTagAsync("OperatorMessage", 2);
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value).IsEqualTo("OK!");
+    }
+
+    [Test]
+    public async Task WriteStringByTagAsyncEncodesPackedAsciiWords()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5028,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType
+OperatorMessage,D600,String
+"""),
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baseline = await rawClient.WriteWordsAsync("D600", [0x4B4F, 0x0021]);
+        var result = await client.WriteStringByTagAsync("OperatorMessage", "OK!", 2);
+
+        await Assert.That(baseline.IsSucceed).IsTrue();
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests[0].Payload).IsEquivalentTo(rawTransport.Requests[0].Payload);
+    }
+
+    [Test]
+    public async Task CsvImportPreservesExtendedSchemaColumnsAndNormalizesValues()
+    {
+        var database = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,Length,Encoding,Units,Signed,ByteOrder
+SignedTotal,D700,int32,2,utf8,items,true,bigendian
+""");
+
+        var tag = database.GetRequired("SignedTotal");
+
+        await Assert.That(tag.DataType).IsEqualTo("Int32");
+        await Assert.That(tag.Length).IsEqualTo(2);
+        await Assert.That(tag.Encoding).IsEqualTo("Utf8");
+        await Assert.That(tag.Units).IsEqualTo("items");
+        await Assert.That(tag.Signed).IsEqualTo(true);
+        await Assert.That(tag.ByteOrder).IsEqualTo("BigEndian");
+    }
+
+    [Test]
+    public async Task CsvImportRejectsUnsupportedByteOrderValues()
+    {
+        try
+        {
+            _ = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,ByteOrder
+SignedTotal,D700,Int32,MiddleEndian
+""");
+            throw new InvalidOperationException("Expected CSV import to reject unknown ByteOrder values.");
+        }
+        catch (FormatException exception)
+        {
+            await Assert.That(exception.Message.Contains("ByteOrder", StringComparison.OrdinalIgnoreCase)).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task ReadInt16ByTagAsyncReadsTwosComplementWord()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x9C, 0xFF],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5029,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,Signed
+SignedTemp,D700,Int16,true
+"""),
+        };
+
+        var result = await client.ReadInt16ByTagAsync("SignedTemp");
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value).IsEqualTo((short)-100);
+    }
+
+    [Test]
+    public async Task WriteInt32ByTagAsyncHonorsBigEndianByteOrder()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5030,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,ByteOrder
+SignedTotal,D700,Int32,BigEndian
+"""),
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baseline = await rawClient.WriteWordsAsync("D700", [0x1234, 0x5678]);
+        var result = await client.WriteInt32ByTagAsync("SignedTotal", 0x12345678);
+
+        await Assert.That(baseline.IsSucceed).IsTrue();
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests[0].Payload).IsEquivalentTo(rawTransport.Requests[0].Payload);
+    }
+
+    [Test]
+    public async Task ReadStringByTagAsyncWithoutExplicitLengthUsesTagLengthAndEncoding()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x06, 0x00, 0x00, 0x00, 0x41, 0xC3, 0xA9, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5031,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,Length,Encoding
+OperatorMessage,D600,String,2,Utf8
+"""),
+        };
+
+        var result = await client.ReadStringByTagAsync("OperatorMessage");
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value).IsEqualTo("Aé");
+    }
+
+    [Test]
+    public async Task WriteStringByTagAsyncWithoutExplicitLengthUsesTagLengthAndBigEndianByteOrder()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5032,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,Length,Encoding,ByteOrder
+OperatorMessage,D600,String,1,Ascii,BigEndian
+"""),
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baseline = await rawClient.WriteWordsAsync("D600", [0x4F4B]);
+        var result = await client.WriteStringByTagAsync("OperatorMessage", "OK");
+
+        await Assert.That(baseline.IsSucceed).IsTrue();
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests[0].Payload).IsEquivalentTo(rawTransport.Requests[0].Payload);
+    }
+
+    [Test]
+    public async Task ReadScaledDoubleByTagAsyncUsesSignedWordMetadata()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x9C, 0xFF],
+        ]);
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5033,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = MitsubishiTagDatabase.FromCsv("""
+Name,Address,DataType,Scale,Offset,Signed
+SignedTemp,D700,Word,0.1,0,true
+"""),
+        };
+
+        var result = await client.ReadScaledDoubleByTagAsync("SignedTemp");
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value).IsEqualTo(-10.0d);
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiTagGroupTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiTagGroupTests.cs
@@ -1,0 +1,125 @@
+using System.Reactive.Concurrency;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiTagGroupTests
+{
+    [Test]
+    public async Task ValidateTagDatabaseFailsForInvalidAddressesAndUnknownGroupMembers()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("BadWord", "BAD100", DataType: "Word"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String"),
+        ]);
+
+        database.AddGroup(new MitsubishiTagGroupDefinition("Line1", ["BadWord", "MissingTag", "OperatorMessage"]));
+
+        var client = new MitsubishiRx(new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5034,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010),
+            new FakeTransport(Array.Empty<byte[]>()),
+            Scheduler.Immediate)
+        {
+            TagDatabase = database,
+        };
+
+        var result = client.ValidateTagDatabase();
+
+        await Assert.That(result.IsSucceed).IsFalse();
+        await Assert.That(result.ErrList.Any(static err => err.Contains("BadWord", StringComparison.OrdinalIgnoreCase))).IsTrue();
+        await Assert.That(result.ErrList.Any(static err => err.Contains("MissingTag", StringComparison.OrdinalIgnoreCase))).IsTrue();
+        await Assert.That(result.ErrList.Any(static err => err.Contains("Length", StringComparison.OrdinalIgnoreCase))).IsTrue();
+    }
+
+    [Test]
+    public async Task ReadTagGroupSnapshotAsyncReturnsTypedValuesInGroupOrder()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x9C, 0xFF],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x06, 0x00, 0x00, 0x00, 0x78, 0x56, 0x34, 0x12],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x06, 0x00, 0x00, 0x00, 0x4F, 0x4B, 0x21, 0x00],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x03, 0x00, 0x00, 0x00, 0x11],
+        ]);
+
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("SignedTemp", "D700", DataType: "Int16", Signed: true),
+            new MitsubishiTagDefinition("TotalCount", "D400", DataType: "UInt32"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Length: 2),
+            new MitsubishiTagDefinition("PumpRunning", "M10", DataType: "Bit"),
+        ]);
+        database.AddGroup(new MitsubishiTagGroupDefinition("Line1", ["SignedTemp", "TotalCount", "OperatorMessage", "PumpRunning"]));
+
+        var client = new MitsubishiRx(new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5035,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010),
+            transport,
+            Scheduler.Immediate)
+        {
+            TagDatabase = database,
+        };
+
+        var result = await client.ReadTagGroupSnapshotAsync("Line1");
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value!.GroupName).IsEqualTo("Line1");
+        await Assert.That(result.Value.TagNames).IsEquivalentTo(new[] { "SignedTemp", "TotalCount", "OperatorMessage", "PumpRunning" });
+        await Assert.That(result.Value.GetRequired<short>("SignedTemp")).IsEqualTo((short)-100);
+        await Assert.That(result.Value.GetRequired<uint>("TotalCount")).IsEqualTo(0x12345678u);
+        await Assert.That(result.Value.GetRequired<string>("OperatorMessage")).IsEqualTo("OK!");
+        await Assert.That(result.Value.GetRequired<bool>("PumpRunning")).IsEqualTo(true);
+        await Assert.That(transport.Requests.Select(static request => request.Description).ToArray()).IsEquivalentTo(new[]
+        {
+            "Read words D700",
+            "Read words D400",
+            "Read words D600",
+            "Read bits M10",
+        });
+    }
+
+    [Test]
+    public async Task ReadTagGroupSnapshotAsyncReturnsScaledEngineeringValuesWhenConfigured()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0xFA, 0x00],
+        ]);
+
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("HeadTemp", "D200", DataType: "Word", Scale: 0.1, Offset: -10, Units: "°C"),
+        ]);
+        database.AddGroup(new MitsubishiTagGroupDefinition("Thermals", ["HeadTemp"]));
+
+        var client = new MitsubishiRx(new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5036,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010),
+            transport,
+            Scheduler.Immediate)
+        {
+            TagDatabase = database,
+        };
+
+        var result = await client.ReadTagGroupSnapshotAsync("Thermals");
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value!.GetRequired<double>("HeadTemp")).IsEqualTo(15.0d);
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiTagGroupWriteTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiTagGroupWriteTests.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiTagGroupWriteTests
+{
+    [Test]
+    public async Task ValidateTagGroupWriteReportsUnsupportedValueTypesAndUnknownTags()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("RecipeNumber", "D300", DataType: "UInt16"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Length: 2),
+        ]);
+        database.AddGroup(new MitsubishiTagGroupDefinition("RecipeWrite", ["RecipeNumber", "OperatorMessage"]));
+
+        var client = new MitsubishiRx(new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5040,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010),
+            new FakeTransport(Array.Empty<byte[]>()),
+            Scheduler.Immediate)
+        {
+            TagDatabase = database,
+        };
+
+        var result = client.ValidateTagGroupWrite(
+            "RecipeWrite",
+            new Dictionary<string, object?>
+            {
+                ["RecipeNumber"] = "not-a-number",
+                ["MissingTag"] = 12,
+            });
+
+        await Assert.That(result.IsSucceed).IsFalse();
+        await Assert.That(result.ErrList.Any(static err => err.Contains("RecipeNumber", StringComparison.OrdinalIgnoreCase))).IsTrue();
+        await Assert.That(result.ErrList.Any(static err => err.Contains("MissingTag", StringComparison.OrdinalIgnoreCase))).IsTrue();
+    }
+
+    [Test]
+    public async Task WriteTagGroupValuesAsyncWritesOnlyProvidedValuesInGroupOrder()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("RecipeNumber", "D300", DataType: "UInt16"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Length: 2),
+            new MitsubishiTagDefinition("PumpRunning", "M10", DataType: "Bit"),
+        ]);
+        database.AddGroup(new MitsubishiTagGroupDefinition("RecipeWrite", ["RecipeNumber", "OperatorMessage", "PumpRunning"]));
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5041,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = database,
+        };
+
+        var rawTransport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var rawClient = new MitsubishiRx(options, rawTransport, Scheduler.Immediate);
+        var baselineWord = await rawClient.WriteWordsAsync("D300", [(ushort)7]);
+        var baselineString = await rawClient.WriteWordsAsync("D600", [0x4B4F, 0x0021]);
+
+        await Assert.That(baselineWord.IsSucceed).IsTrue();
+        await Assert.That(baselineString.IsSucceed).IsTrue();
+
+        var result = await client.WriteTagGroupValuesAsync(
+            "RecipeWrite",
+            new Dictionary<string, object?>
+            {
+                ["RecipeNumber"] = (ushort)7,
+                ["OperatorMessage"] = "OK!",
+            });
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests.Count).IsEqualTo(2);
+        await Assert.That(transport.Requests[0].Description).IsEqualTo("Write words D300");
+        await Assert.That(transport.Requests[1].Description).IsEqualTo("Write words D600");
+    }
+
+    [Test]
+    public async Task WriteTagGroupSnapshotAsyncWritesTypedSnapshotValues()
+    {
+        var transport = new FakeTransport(
+        [
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+            [0xD0, 0x00, 0x00, 0xFF, 0xFF, 0x03, 0x00, 0x02, 0x00, 0x00, 0x00],
+        ]);
+
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("SignedTemp", "D700", DataType: "Int16", Signed: true),
+            new MitsubishiTagDefinition("TotalCount", "D400", DataType: "UInt32"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Length: 2),
+        ]);
+        database.AddGroup(new MitsubishiTagGroupDefinition("Line1Overview", ["SignedTemp", "TotalCount", "OperatorMessage"]));
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5042,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Binary,
+            TransportKind: MitsubishiTransportKind.Tcp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate)
+        {
+            TagDatabase = database,
+        };
+
+        var snapshot = new MitsubishiTagGroupSnapshot(
+            "Line1Overview",
+            new Dictionary<string, object?>
+            {
+                ["SignedTemp"] = (short)-100,
+                ["TotalCount"] = 0x12345678u,
+                ["OperatorMessage"] = "OK!",
+            });
+
+        var result = await client.WriteTagGroupSnapshotAsync(snapshot);
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(transport.Requests.Count).IsEqualTo(3);
+        await Assert.That(transport.Requests.Select(static request => request.Description).ToArray()).IsEquivalentTo(new[]
+        {
+            "Write words D700",
+            "Write words D400",
+            "Write words D600",
+        });
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiTagSchemaFileIoTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiTagSchemaFileIoTests.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiTagSchemaFileIoTests
+{
+    [Test]
+    public async Task SaveAndLoadJsonRoundTripPreservesTagsAndGroups()
+    {
+        var database = CreateSchemaDatabase();
+        var path = CreateTempPath("json");
+
+        try
+        {
+            database.Save(path);
+            var loaded = MitsubishiTagDatabase.Load(path);
+
+            await Assert.That(File.Exists(path)).IsTrue();
+            await Assert.That(loaded.Count).IsEqualTo(3);
+            await Assert.That(loaded.GroupCount).IsEqualTo(1);
+            await Assert.That(loaded.GetRequired("OperatorMessage").Encoding).IsEqualTo("Utf8");
+            await Assert.That(loaded.GetRequiredGroup("Overview").ResolvedTagNames).IsEquivalentTo(new[] { "SignedTemp", "TotalCount", "OperatorMessage" });
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task SaveAndLoadYamlRoundTripPreservesTagsAndGroups()
+    {
+        var database = CreateSchemaDatabase();
+        var path = CreateTempPath("yaml");
+
+        try
+        {
+            database.Save(path);
+            var loaded = MitsubishiTagDatabase.Load(path);
+
+            await Assert.That(File.ReadAllText(path).Contains("groups:", StringComparison.OrdinalIgnoreCase)).IsTrue();
+            await Assert.That(loaded.Count).IsEqualTo(3);
+            await Assert.That(loaded.GroupCount).IsEqualTo(1);
+            await Assert.That(loaded.GetRequired("TotalCount").ByteOrder).IsEqualTo("LittleEndian");
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task SaveAndLoadYamlWithYmlExtensionUsesYamlFormatDetection()
+    {
+        var database = CreateSchemaDatabase();
+        var path = CreateTempPath("yml");
+
+        try
+        {
+            database.Save(path);
+            var loaded = MitsubishiTagDatabase.Load(path);
+
+            await Assert.That(File.ReadAllText(path).Contains("groups:", StringComparison.OrdinalIgnoreCase)).IsTrue();
+            await Assert.That(loaded.Count).IsEqualTo(3);
+            await Assert.That(loaded.GroupCount).IsEqualTo(1);
+            await Assert.That(loaded.GetRequired("OperatorMessage").ByteOrder).IsEqualTo("BigEndian");
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task SaveAndLoadCsvUsesCsvFormatDetection()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("MotorSpeed", "D100", DataType: "Word", Scale: 0.1, Units: "rpm"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Length: 4, Encoding: "Utf8", Notes: "Shown on HMI"),
+        ]);
+
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["MotorSpeed", "OperatorMessage"]));
+        var path = CreateTempPath("csv");
+
+        try
+        {
+            database.Save(path);
+            var loaded = MitsubishiTagDatabase.Load(path);
+
+            var csv = File.ReadAllText(path);
+            await Assert.That(csv.Contains("Name,Address,DataType", StringComparison.Ordinal)).IsTrue();
+            await Assert.That(loaded.Count).IsEqualTo(2);
+            await Assert.That(loaded.GroupCount).IsEqualTo(0);
+            await Assert.That(loaded.GetRequired("MotorSpeed").Units).IsEqualTo("rpm");
+            await Assert.That(loaded.GetRequired("OperatorMessage").Length).IsEqualTo(4);
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    [Test]
+    public async Task LoadRejectsUnsupportedSchemaExtensions()
+    {
+        var path = CreateTempPath("txt");
+
+        try
+        {
+            File.WriteAllText(path, "unsupported");
+
+            var exception = Assert.Throws<NotSupportedException>(() => MitsubishiTagDatabase.Load(path));
+            if (exception is null)
+            {
+                throw new InvalidOperationException("Expected Load to reject unsupported schema extensions.");
+            }
+
+            await Assert.That(exception.Message.Contains(".txt", StringComparison.OrdinalIgnoreCase)).IsTrue();
+        }
+        finally
+        {
+            DeleteIfExists(path);
+        }
+    }
+
+    private static MitsubishiTagDatabase CreateSchemaDatabase()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("SignedTemp", "D700", DataType: "Int16", Signed: true, Units: "°C"),
+            new MitsubishiTagDefinition("TotalCount", "D400", DataType: "UInt32", ByteOrder: "LittleEndian", Units: "items"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Length: 2, Encoding: "Utf8", ByteOrder: "BigEndian"),
+        ]);
+
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["SignedTemp", "TotalCount", "OperatorMessage"]));
+        return database;
+    }
+
+    private static string CreateTempPath(string extension)
+        => Path.Combine(Path.GetTempPath(), $"mitsubishirx-schema-{Guid.NewGuid():N}.{extension}");
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiTagSchemaSerializationTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiTagSchemaSerializationTests.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiTagSchemaSerializationTests
+{
+    [Test]
+    public async Task ToJsonAndFromJsonRoundTripPreservesTagsAndGroups()
+    {
+        var database = CreateSchemaDatabase();
+
+        var json = database.ToJson();
+        var roundTripped = MitsubishiTagDatabase.FromJson(json);
+
+        await Assert.That(json.Contains("\"groups\"", StringComparison.OrdinalIgnoreCase)).IsTrue();
+        await Assert.That(roundTripped.Count).IsEqualTo(3);
+        await Assert.That(roundTripped.GroupCount).IsEqualTo(1);
+
+        var signedTemp = roundTripped.GetRequired("SignedTemp");
+        await Assert.That(signedTemp.DataType).IsEqualTo("Int16");
+        await Assert.That(signedTemp.Signed).IsTrue();
+
+        var operatorMessage = roundTripped.GetRequired("OperatorMessage");
+        await Assert.That(operatorMessage.Length).IsEqualTo(2);
+        await Assert.That(operatorMessage.Encoding).IsEqualTo("Utf8");
+        await Assert.That(operatorMessage.ByteOrder).IsEqualTo("BigEndian");
+
+        var group = roundTripped.GetRequiredGroup("Overview");
+        await Assert.That(group.ResolvedTagNames).IsEquivalentTo(new[] { "SignedTemp", "TotalCount", "OperatorMessage" });
+    }
+
+    [Test]
+    public async Task ToYamlAndFromYamlRoundTripPreservesTagsAndGroups()
+    {
+        var database = CreateSchemaDatabase();
+
+        var yaml = database.ToYaml();
+        var roundTripped = MitsubishiTagDatabase.FromYaml(yaml);
+
+        await Assert.That(yaml.Contains("groups:", StringComparison.OrdinalIgnoreCase)).IsTrue();
+        await Assert.That(roundTripped.Count).IsEqualTo(3);
+        await Assert.That(roundTripped.GroupCount).IsEqualTo(1);
+        await Assert.That(roundTripped.GetRequired("TotalCount").ByteOrder).IsEqualTo("LittleEndian");
+        await Assert.That(roundTripped.GetRequiredGroup("Overview").ResolvedTagNames[0]).IsEqualTo("SignedTemp");
+    }
+
+    [Test]
+    public async Task FromYamlParsesManualSchemaDocumentWithGroups()
+    {
+        var yaml = """
+        tags:
+          - name: SignedTemp
+            address: D700
+            dataType: Int16
+            signed: true
+            units: °C
+          - name: OperatorMessage
+            address: D600
+            dataType: String
+            length: 2
+            encoding: Utf8
+            byteOrder: BigEndian
+        groups:
+          - name: Overview
+            tagNames:
+              - SignedTemp
+              - OperatorMessage
+        """;
+
+        var database = MitsubishiTagDatabase.FromYaml(yaml);
+
+        await Assert.That(database.Count).IsEqualTo(2);
+        await Assert.That(database.GroupCount).IsEqualTo(1);
+        await Assert.That(database.GetRequired("SignedTemp").Signed).IsTrue();
+        await Assert.That(database.GetRequired("OperatorMessage").Encoding).IsEqualTo("Utf8");
+        await Assert.That(database.GetRequiredGroup("Overview").ResolvedTagNames).IsEquivalentTo(new[] { "SignedTemp", "OperatorMessage" });
+    }
+
+    private static MitsubishiTagDatabase CreateSchemaDatabase()
+    {
+        var database = new MitsubishiTagDatabase(
+        [
+            new MitsubishiTagDefinition("SignedTemp", "D700", DataType: "Int16", Signed: true, Units: "°C"),
+            new MitsubishiTagDefinition("TotalCount", "D400", DataType: "UInt32", ByteOrder: "LittleEndian", Units: "items"),
+            new MitsubishiTagDefinition("OperatorMessage", "D600", DataType: "String", Length: 2, Encoding: "Utf8", ByteOrder: "BigEndian"),
+        ]);
+
+        database.AddGroup(new MitsubishiTagGroupDefinition("Overview", ["SignedTemp", "TotalCount", "OperatorMessage"]));
+        return database;
+    }
+}

--- a/tests/MitsubishiRx.Tests/MitsubishiUdpTests.cs
+++ b/tests/MitsubishiRx.Tests/MitsubishiUdpTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+
+namespace MitsubishiRx.Tests;
+
+public sealed class MitsubishiUdpTests
+{
+    [Test]
+    public async Task ReadWordsAsyncAsciiUdpRoundTripsThroughDynamicResponse()
+    {
+        var transport = new FakeTransport(request =>
+        {
+            _ = System.Text.Encoding.ASCII.GetString(request.Payload);
+            return System.Text.Encoding.ASCII.GetBytes("D00000FF03FF000006000000425678");
+        });
+
+        var options = new MitsubishiClientOptions(
+            Host: "127.0.0.1",
+            Port: 5014,
+            FrameType: MitsubishiFrameType.ThreeE,
+            DataCode: CommunicationDataCode.Ascii,
+            TransportKind: MitsubishiTransportKind.Udp,
+            Route: MitsubishiRoute.Default,
+            MonitoringTimer: 0x0010);
+
+        var client = new MitsubishiRx(options, transport, Scheduler.Immediate);
+        var result = await client.ReadWordsAsync("D100", 2);
+        if (!result.IsSucceed)
+        {
+            throw new InvalidOperationException(result.Err);
+        }
+
+        await Assert.That(result.IsSucceed).IsTrue();
+        await Assert.That(result.Value!.Select(static value => (int)value).ToArray()).IsEquivalentTo([0x0042, 0x5678]);
+        await Assert.That(transport.Requests[0].Description).IsEqualTo("Read words D100");
+    }
+}

--- a/tests/MitsubishiRx.Tests/UnitTest1.cs
+++ b/tests/MitsubishiRx.Tests/UnitTest1.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MitsubishiRx.Tests;
+
+public sealed class Placeholder
+{
+}


### PR DESCRIPTION
Introduce the MitsubishiRx project: add core library sources, protocol encodings, serial and reactive transports, tag database and rollout/serialization support, and a comprehensive README. 

Many new files implement MC Protocol/SLMP (Ethernet 1E/3E/4E and serial 1C/3C/4C), reactive SerialPortRx integration, tag/group schema, and tests. 

Update Directory.Build.props to reflect package metadata (description, tags, project/repository URLs) and include README.md in the package.