### PR TITLE
Use concrete Heartbeat/Stale types, bump SerialPortRx

### DIFF
--- a/src/MitsubishiRx.Tests/MitsubishiReactivePollingTests.cs
+++ b/src/MitsubishiRx.Tests/MitsubishiReactivePollingTests.cs
@@ -29,7 +29,7 @@ public sealed class MitsubishiReactivePollingTests
             MonitoringTimer: 0x0010);
 
         var client = new MitsubishiRx(options, transport, scheduler);
-        var received = new List<IHeartbeat<Responce<ushort[]>>>();
+        var received = new List<Heartbeat<Responce<ushort[]>>>();
 
         using var subscription = client
             .ObserveWordsHeartbeat("D100", 1, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10), TimeSpan.FromSeconds(30))

--- a/src/MitsubishiRx.Tests/MitsubishiReactiveTagGroupTests.cs
+++ b/src/MitsubishiRx.Tests/MitsubishiReactiveTagGroupTests.cs
@@ -41,7 +41,7 @@ public sealed class MitsubishiReactiveTagGroupTests
             TagDatabase = database,
         };
 
-        var received = new List<IHeartbeat<Responce<MitsubishiTagGroupSnapshot>>>();
+        var received = new List<Heartbeat<Responce<MitsubishiTagGroupSnapshot>>>();
 
         using var subscription = client
             .ObserveTagGroupHeartbeat("Recipe", TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10))
@@ -93,7 +93,7 @@ public sealed class MitsubishiReactiveTagGroupTests
             TagDatabase = database,
         };
 
-        var received = new List<IStale<Responce<MitsubishiTagGroupSnapshot>>>();
+        var received = new List<Stale<Responce<MitsubishiTagGroupSnapshot>>>();
 
         using var subscription = client
             .ObserveTagGroupStale("Recipe", TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10))

--- a/src/MitsubishiRx/MitsubishiRx.cs
+++ b/src/MitsubishiRx/MitsubishiRx.cs
@@ -1267,7 +1267,7 @@ public sealed partial class MitsubishiRx : IDisposable, IAsyncDisposable
     /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
     /// <param name="pollTimeout">Per-poll timeout.</param>
     /// <returns>Observable heartbeat stream.</returns>
-    public IObservable<IHeartbeat<Responce<ushort[]>>> ObserveWordsHeartbeat(string address, int points, TimeSpan pollInterval, TimeSpan heartbeatAfter, TimeSpan? minimumUpdateSpacing = null, TimeSpan? pollTimeout = null)
+    public IObservable<Heartbeat<Responce<ushort[]>>> ObserveWordsHeartbeat(string address, int points, TimeSpan pollInterval, TimeSpan heartbeatAfter, TimeSpan? minimumUpdateSpacing = null, TimeSpan? pollTimeout = null)
         => ObserveWords(address, points, pollInterval, minimumUpdateSpacing, pollTimeout).Heartbeat(heartbeatAfter, _scheduler);
 
     /// <summary>
@@ -1279,7 +1279,7 @@ public sealed partial class MitsubishiRx : IDisposable, IAsyncDisposable
     /// <param name="staleAfter">Staleness threshold.</param>
     /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
     /// <returns>Observable stale-aware stream.</returns>
-    public IObservable<IStale<Responce<ushort[]>>> ObserveWordsStale(string address, int points, TimeSpan pollInterval, TimeSpan staleAfter, TimeSpan? minimumUpdateSpacing = null)
+    public IObservable<Stale<Responce<ushort[]>>> ObserveWordsStale(string address, int points, TimeSpan pollInterval, TimeSpan staleAfter, TimeSpan? minimumUpdateSpacing = null)
         => ObserveWords(address, points, pollInterval, minimumUpdateSpacing).DetectStale(staleAfter, _scheduler);
 
     /// <summary>
@@ -1317,7 +1317,7 @@ public sealed partial class MitsubishiRx : IDisposable, IAsyncDisposable
     /// <param name="heartbeatAfter">Heartbeat interval.</param>
     /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
     /// <returns>Observable heartbeat stream.</returns>
-    public IObservable<IHeartbeat<Responce<MitsubishiTagGroupSnapshot>>> ObserveTagGroupHeartbeat(string groupName, TimeSpan pollInterval, TimeSpan heartbeatAfter, TimeSpan? minimumUpdateSpacing = null)
+    public IObservable<Heartbeat<Responce<MitsubishiTagGroupSnapshot>>> ObserveTagGroupHeartbeat(string groupName, TimeSpan pollInterval, TimeSpan heartbeatAfter, TimeSpan? minimumUpdateSpacing = null)
         => ObserveTagGroup(groupName, pollInterval, minimumUpdateSpacing).Heartbeat(heartbeatAfter, _scheduler);
 
     /// <summary>
@@ -1328,7 +1328,7 @@ public sealed partial class MitsubishiRx : IDisposable, IAsyncDisposable
     /// <param name="staleAfter">Staleness threshold.</param>
     /// <param name="minimumUpdateSpacing">Minimum spacing between notifications.</param>
     /// <returns>Observable stale-aware stream.</returns>
-    public IObservable<IStale<Responce<MitsubishiTagGroupSnapshot>>> ObserveTagGroupStale(string groupName, TimeSpan pollInterval, TimeSpan staleAfter, TimeSpan? minimumUpdateSpacing = null)
+    public IObservable<Stale<Responce<MitsubishiTagGroupSnapshot>>> ObserveTagGroupStale(string groupName, TimeSpan pollInterval, TimeSpan staleAfter, TimeSpan? minimumUpdateSpacing = null)
         => ObserveTagGroup(groupName, pollInterval, minimumUpdateSpacing).DetectStale(staleAfter, _scheduler);
 
     /// <summary>
@@ -1359,7 +1359,7 @@ public sealed partial class MitsubishiRx : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="staleAfter">Staleness threshold.</param>
     /// <returns>Observable health states.</returns>
-    public IObservable<IStale<MitsubishiConnectionState>> ObserveConnectionHealth(TimeSpan staleAfter)
+    public IObservable<Stale<MitsubishiConnectionState>> ObserveConnectionHealth(TimeSpan staleAfter)
         => ConnectionStates.DetectStale(staleAfter, _scheduler);
 
     /// <inheritdoc/>
@@ -1610,7 +1610,7 @@ public sealed partial class MitsubishiRx : IDisposable, IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(payloadFactory);
         var observable = Observable.Defer(() => Observable.FromAsync(ct => ExecuteOnceAsync(payloadFactory, expectedLength, description, ct)))
-            .RetryWithBackoff(maxRetries, TimeSpan.FromMilliseconds(100), scheduler: _scheduler)
+            .RetryWithBackoff(maxRetries, TimeSpan.FromMilliseconds(100), backoffFactor: 2.0, maxDelay: null, scheduler: _scheduler)
             .Catch<Responce<byte[]>, Exception>(ex => Observable.Return(new Responce<byte[]>().Fail(ex.Message, exception: ex)));
 
         return await observable.FirstAsync().ToTask(cancellationToken).ConfigureAwait(false);

--- a/src/MitsubishiRx/MitsubishiRx.csproj
+++ b/src/MitsubishiRx/MitsubishiRx.csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.Extensions" Version="2.3.1" />
-    <PackageReference Include="SerialPortRx" Version="3.4.4" />
+    <PackageReference Include="SerialPortRx" Version="4.0.1" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
     <PackageReference Include="YamlDotNet" Version="18.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Replace IHeartbeat/IStale generic return types with the concrete Heartbeat/Stale types in public APIs and update tests accordingly (MitsubishiRx.cs and test files). Adjust RetryWithBackoff call to pass backoffFactor and maxDelay (keeps retry behavior explicit). Bump SerialPortRx dependency from 3.4.4 to 4.0.1 in the project file.